### PR TITLE
change default cache and results location to ~/.capreolus

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Capreolus uses environment variables to indicate where outputs should be stored 
 
 | Environment Variable          | Default Value | Purpose |
 |-------------------------------|---------------|---------|
-| `CAPREOLUS_RESULTS`             | results/    | Directory where results will be stored   |
-| `CAPREOLUS_CACHE`               | cache/      | Directory used for cache files |
+| `CAPREOLUS_RESULTS`             | ~/.capreolus/results/    | Directory where results will be stored   |
+| `CAPREOLUS_CACHE`               | ~/.capreolus/cache/      | Directory used for cache files |
 | `CUDA_VISIBLE_DEVICES`          | (unset)     | Indicates GPUs available to PyTorch, starting from 0. For example, set to '1' the system's 2nd GPU (as numbered by `nvidia-smi`). Set to '' (an empty string) to force CPU.
 
 

--- a/capreolus/__init__.py
+++ b/capreolus/__init__.py
@@ -4,17 +4,19 @@ from capreolus.utils.loginit import get_logger
 from tqdm import tqdm
 import pytrec_eval
 import numpy as np
-import jnius_config
 import os
+import sysconfig
+import jnius_config
 
 from capreolus.collection import COLLECTIONS
-from capreolus.utils.common import get_capreolus_base_dir
+from capreolus.utils.common import get_capreolus_base_dir, Anserini
 
-if not jnius_config.get_classpath() == "{0}/capreolus/anserini-0.7.0-fatjar.jar".format(get_capreolus_base_dir()):
-    try:
-        jnius_config.set_classpath("{0}/capreolus/anserini-0.7.0-fatjar.jar".format(get_capreolus_base_dir()))
-    except:
-        raise Exception("The classpath is: {0}".format(jnius_config.get_classpath()))
+jnius_config.set_classpath(Anserini.get_fat_jar())
+# if not jnius_config.get_classpath() == "{0}/capreolus/anserini-0.7.0-fatjar.jar".format(get_capreolus_base_dir()):
+#     try:
+#         jnius_config.set_classpath("{0}/capreolus/anserini-0.7.0-fatjar.jar".format(get_capreolus_base_dir()))
+#     except:
+#         raise Exception("The classpath is: {0}".format(jnius_config.get_classpath()))
 
 
 import functools

--- a/capreolus/crawl_collection.py
+++ b/capreolus/crawl_collection.py
@@ -7,10 +7,12 @@ from multiprocessing import Manager, Process, Pool
 
 from tqdm import tqdm
 
-from capreolus.utils.common import Anserini, get_default_cache_dir
-from capreolus.utils.loginit import get_logger
-
-logger = get_logger(__name__)  # pylint: disable=invalid-name
+# Duplicated util function - we don't want to import from capreolus.utils due to jnius woes
+def get_default_cache_dir():
+    default_dir = os.path.expanduser("~/.capreolus/cache/")
+    if not os.path.exists(default_dir):
+        os.makedirs(os.path.dirname(default_dir))
+    return default_dir
 
 
 def crawl():
@@ -25,7 +27,7 @@ def crawl():
     manager = Manager()
     shared_dict = manager.dict()
     multiprocess_start = time.time()
-    logger.debug("Start multiprocess")
+    print("Start multiprocess")
     args_list = []
     for subdir in os.listdir(rootdir):
         if os.path.isdir(rootdir + "/" + subdir):
@@ -34,7 +36,7 @@ def crawl():
     pool = Pool(processes=8)
     pool.map(spawn_child_process_to_read_docs, args_list)
 
-    logger.debug("Getting all documents from disk took: {0}".format(time.time() - multiprocess_start))
+    print("Getting all documents from disk took: {0}".format(time.time() - multiprocess_start))
     # TODO: This will fail if multiple crawls are running at the same time
     with open("{0}/disk_crawl_temp_dump.json".format(os.getenv("CAPREOLUS_CACHE", get_default_cache_dir())), "w") as fp:
         json.dump(shared_dict.copy(), fp)
@@ -58,7 +60,7 @@ def spawn_child_process_to_read_docs(data):
         for i, doc_id in enumerate(doc_ids):
             local_dict[doc_id] = doc_contents[i]
     shared_dict.update(local_dict)
-    logger.debug("PID: {0}, Done getting documents from disk: {1} for path: {2}".format(os.getpid(), time.time() - start, path))
+    print("PID: {0}, Done getting documents from disk: {1} for path: {2}".format(os.getpid(), time.time() - start, path))
 
 
 def read_file_segment(target_doc_ids, file_segment, generator):

--- a/capreolus/index/anserini.py
+++ b/capreolus/index/anserini.py
@@ -3,7 +3,7 @@ import math
 import os
 import subprocess
 import time
-from jnius import autoclass
+# from jnius import autoclass
 
 from capreolus.index import Index
 from capreolus.tokenizer import Tokenizer
@@ -89,6 +89,7 @@ class AnseriniIndex(Index):
             ["python", get_crawl_collection_script(), rootdir, ctype],
             stdout=subprocess.PIPE,
             input=",".join(doc_ids),
+            check=True,
             encoding="utf-8",
         )
         with open("{0}/disk_crawl_temp_dump.json".format(os.getenv("CAPREOLUS_CACHE", get_default_cache_dir())), "rt") as fp:
@@ -126,6 +127,7 @@ class AnseriniIndex(Index):
         return self._tokenizer
 
     def open(self):
+        from jnius import autoclass
         JIndexUtils = autoclass("io.anserini.index.IndexUtils")
         self.index_utils = JIndexUtils(self.index_path)
 

--- a/capreolus/utils/common.py
+++ b/capreolus/utils/common.py
@@ -128,11 +128,11 @@ def import_component_modules(name):
 
 
 def get_default_cache_dir():
-    return "{0}/cache".format(get_capreolus_base_dir())
+    return "{0}/cache".format(os.getcwd())
 
 
 def get_default_results_dir():
-    return "{0}/results".format(get_capreolus_base_dir())
+    return "{0}/results".format(os.getcwd())
 
 
 def get_crawl_collection_script():

--- a/capreolus/utils/common.py
+++ b/capreolus/utils/common.py
@@ -1,11 +1,11 @@
 import hashlib
 import importlib
 import os
+import sysconfig
 import requests
 import sys
 from glob import glob
 
-import jnius_config
 from tqdm import tqdm
 from capreolus.utils.loginit import get_logger
 
@@ -31,8 +31,8 @@ def padlist(list_to_pad, padlen, pad_token=0):
 class Anserini:
     @classmethod
     def get_fat_jar(cls):
-        basedir = get_capreolus_base_dir()
-        paths = glob(os.path.join(basedir, "capreolus", "anserini-*-fatjar.jar"))
+        jar_path = "{0}/pyserini/resources/jars/".format(sysconfig.get_paths()['purelib'])
+        paths = glob(os.path.join(jar_path, "anserini-*-fatjar.jar"))
 
         latest = max(paths, key=os.path.getctime)
         return latest
@@ -128,11 +128,17 @@ def import_component_modules(name):
 
 
 def get_default_cache_dir():
-    return "{0}/cache".format(os.getcwd())
+    default_dir = os.path.expanduser("~/.capreolus/cache/")
+    if not os.path.exists(default_dir):
+        os.makedirs(os.path.dirname(default_dir))
+    return default_dir
 
 
 def get_default_results_dir():
-    return "{0}/results".format(os.getcwd())
+    default_dir = os.path.expanduser("~/.capreolus/results/")
+    if not os.path.exists(default_dir):
+        os.makedirs(os.path.dirname(default_dir))
+    return default_dir
 
 
 def get_crawl_collection_script():

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ The CLI takes a command to run, such as the `train`, and optionally a list of co
 `capreolus <command> [with <configuration options>]`. If no command is specified, `train` is used as the default. Configuration options are specified in `key=value` format.
 
 ### Train Command
-The `train` command trains a reranking model for `niters` iterations on a single training set. This command displays the *results path*, where the experiment's output will be stored, at the beginning of training. As described above, this (long) path is a combination of a root directory and a string encoding all configuration options influencing the experiment's output. The root directory is indicated by the `$CAPREOLUS_RESULTS` environment variable and defaults to `results/` if unset.
+The `train` command trains a reranking model for `niters` iterations on a single training set. This command displays the *results path*, where the experiment's output will be stored, at the beginning of training. As described above, this (long) path is a combination of a root directory and a string encoding all configuration options influencing the experiment's output. The root directory is indicated by the `$CAPREOLUS_RESULTS` environment variable and defaults to `~/.capreolus/results/` if unset.
 
 **Example:**
 `capreolus train with reranker=KNRM niters=10 benchmark=robust04.title.wsdm20demo fold=s1`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,8 +24,8 @@ Setup a Python 3.6+ environment in your home directory. We strongly recommend us
 
 ### Configuring Capreolus
  Capreolus uses environment variables to indicate where outputs should be stored and where document inputs can be found. Consult the list below to determine which variables should be set. [Set these environment variables](https://opensource.com/article/19/8/what-are-environment-variables) either on the fly (`export CAPREOLUS_RESULTS=...`) before running Capreolus or by editing your shell's initialization files (e.g., `~/.bashrc` or `~/.zshrc`).
-- `CAPREOLUS_RESULTS`: the directory where results will be stored. If unset, defaults to `results/` in the current directory.
-- `CAPREOLUS_CACHE`: the directory where cache files are stored. If unset, defaults to `cache/` in the current directory.
+- `CAPREOLUS_RESULTS`: the directory where results will be stored. If unset, defaults to `~/.capreolus/results/`
+- `CAPREOLUS_CACHE`: the directory where cache files are stored. If unset, defaults to `~/.capreolus/cache/`
 - `CAPREOLUS_LOGGING`: Indicates the logging level. Can take on the values `INFO`, `DEBUG`, `WARN` and `ERROR`
 - `CUDA_VISIBLE_DEVICES`: Indicates GPUs available to PyTorch, starting from 0. For example, setting to '1' will use the system's 2nd GPU (as numbered by `nvidia-smi`). Set to '' (an empty string) to force CPU. 
 


### PR DESCRIPTION
This changes the default cache and results directories to ~/.capreolus/{results,cache}. (Currently parent of capreolus' pip install directory is used, but this is unintuitive and will likely result in leaving files around that people are unaware of.) Closes #2 