### PR TITLE
Group config options by module when calling print_config command

### DIFF
--- a/capreolus/benchmark/dummy.py
+++ b/capreolus/benchmark/dummy.py
@@ -16,7 +16,7 @@ class DummyBenchmark(Benchmark):
     def config():
         searcher = "bm25grid"
         collection = "dummy"
-        rundocsonly = False
+        rundocsonly = False  # use only docs from the searcher as pos/neg training instances (i.e., not all qrels)
         return locals().copy()  # ignored by sacred
 
     def build(self):

--- a/capreolus/extractor/bagofwords.py
+++ b/capreolus/extractor/bagofwords.py
@@ -25,8 +25,8 @@ class BagOfWords(Extractor):
 
     @staticmethod
     def config():
-        datamode = "unigram"  # DSSM requires trigram vector as input
-        keepstops = False
+        datamode = "unigram"  # type of input: 'unigram' or 'trigram'
+        keepstops = False  # include stopwords in the reranker's input
         return locals().copy()  # ignored by sacred
 
     def build_unigram_stoi(self, toks_list, keepstops, calculate_idf):

--- a/capreolus/extractor/deeptileextractor.py
+++ b/capreolus/extractor/deeptileextractor.py
@@ -48,9 +48,9 @@ class DeepTileExtractor(Extractor, BuildStoIMixin):
 
     @staticmethod
     def config():
-        tfchannel = True
+        tfchannel = True  # include TF as a channel
         slicelen = 20
-        keepstops = False
+        keepstops = False  # include stopwords in the reranker's input
         return locals().copy()  # ignored by sacred
 
     def get_magnitude_embeddings(self, embedding_name):

--- a/capreolus/extractor/embedtext.py
+++ b/capreolus/extractor/embedtext.py
@@ -39,7 +39,7 @@ class EmbedText(Extractor, BuildStoIMixin):
     @staticmethod
     def config():
         embeddings = "glove6b"  # static embedding file to use: glove6b, glove6b.50d, w2vnews, or fasttext
-        keepstops = False  # keep stopwords? discard them if False
+        keepstops = False  # include stopwords in the reranker's input
         return locals().copy()  # ignored by sacred
 
     def get_magnitude_embeddings(self, embedding_name):

--- a/capreolus/index/anserini.py
+++ b/capreolus/index/anserini.py
@@ -3,7 +3,6 @@ import math
 import os
 import subprocess
 import time
-# from jnius import autoclass
 
 from capreolus.index import Index
 from capreolus.tokenizer import Tokenizer
@@ -31,8 +30,8 @@ class AnseriniIndex(Index):
 
     @staticmethod
     def config():
-        stemmer = "porter"
-        indexstops = False
+        stemmer = "porter"  # stemmer to use: 'none', 'krovetz', 'porter'
+        indexstops = False  # include stop words in index
         return locals().copy()  # ignored by sacred
 
     def _build_index(self, config):
@@ -128,6 +127,7 @@ class AnseriniIndex(Index):
 
     def open(self):
         from jnius import autoclass
+
         JIndexUtils = autoclass("io.anserini.index.IndexUtils")
         self.index_utils = JIndexUtils(self.index_path)
 

--- a/capreolus/pipeline.py
+++ b/capreolus/pipeline.py
@@ -398,6 +398,7 @@ def cli_module_choice(argv, module):
     return choice
 
 
+# modified sacred.commands._format_config function that groups config options by module
 def _format_config_by_module(cfg, config_mods, parameters_to_module):
     _iterate_marked = sacred.commands._iterate_marked
 

--- a/capreolus/pipeline.py
+++ b/capreolus/pipeline.py
@@ -443,6 +443,8 @@ def _format_entry(indent, entry):
 
     PRINTER = pprint.PrettyPrinter()
     PRINTER.format = sacred.commands._non_unicode_repr
+    GREY = "\033[90m"
+    ENDC = "\033[0m"
 
     indent = " " * indent
     if entry.key == "__doc__":
@@ -453,7 +455,7 @@ def _format_entry(indent, entry):
     else:  # isinstance(entry, PathEntry):
         assign = indent + entry.key + ":"
     if entry.doc:
-        doc_string = entry.doc
+        doc_string = GREY + "# " + entry.doc + ENDC
         if len(assign) <= 35:
             assign = "{:<35}  {}".format(assign, doc_string)
         else:

--- a/capreolus/pipeline.py
+++ b/capreolus/pipeline.py
@@ -41,8 +41,8 @@ sacred.SETTINGS.HOST_INFO.CAPTURED_ENV.append("USER")
 modules = ("collection", "index", "searcher", "benchmark", "reranker")
 
 
+# default modules
 def module_config():
-    # default modules
     collection = "robust04"
     index = "anserini"
     searcher = "bm25"

--- a/capreolus/pipeline.py
+++ b/capreolus/pipeline.py
@@ -405,6 +405,7 @@ def _format_config_by_module(cfg, config_mods, parameters_to_module):
     for k, module in parameters_to_module.items():
         if module == "module":
             module = k
+            module_configs.setdefault(module, [])
         elif module == "stateless":
             module = "experiment"
         elif module == "extractor":

--- a/capreolus/pipeline.py
+++ b/capreolus/pipeline.py
@@ -56,20 +56,13 @@ def module_config():
 # (e.g., they don't affect model training or they're manually included somewhere in the path)
 def stateless_config():
     expid = "debug"  # experiment id/name
-    predontrain = False
-    fold = "s1"
+    predontrain = False  # predict rankings on the training set
+    fold = "s1"  # fold to use; indicates qids used for training, dev, and test sets
     earlystopping = True
     return locals().copy()  # ignored by sacred
 
 
 def pipeline_config():
-    # not working / disabled
-    # resume = False  # resume from last existing weights, if any exist #TODO make this work with epoch preds
-    # saveall = True
-    # selfprediction = False
-    # uniformunk = True
-    # datamode = "basic"
-
     maxdoclen = 800  # maximum document length (in number of terms after tokenization)
     maxqlen = 4  # maximum query length (in number of terms after tokenization)
     batch = 32  # batch size
@@ -78,9 +71,9 @@ def pipeline_config():
     gradacc = 1  # number of batches to accumulate over before updating weights
     lr = 0.001  # learning rate
     seed = 123_456  # random seed to use
-    sample = "simple"
+    sample = "simple"  # query and doc sampling strategy to use when training: 'simple'
     softmaxloss = True  # True to use softmax loss (over pairs) or False to use hinge loss
-    dataparallel = "none"
+    dataparallel = "none"  # train on a single GPU if 'none' or use all available GPUs if set to 'gpu'
 
     if sample not in ["simple"]:
         raise RuntimeError(f"sample '{sample}' must be one of: simple")

--- a/capreolus/pipeline.py
+++ b/capreolus/pipeline.py
@@ -418,7 +418,7 @@ def _format_config_by_module(cfg, config_mods, parameters_to_module):
     path_to_entry = {path: entry for path, entry in _iterate_marked(cfg, config_mods)}
 
     lines = ["Configuration:"]
-    for module, module_keys in module_configs.items():
+    for module, module_keys in sorted(module_configs.items()):
         indent = 2
 
         if module not in path_to_entry:

--- a/capreolus/pipeline.py
+++ b/capreolus/pipeline.py
@@ -400,7 +400,6 @@ def cli_module_choice(argv, module):
 
 def _format_config_by_module(cfg, config_mods, parameters_to_module):
     _iterate_marked = sacred.commands._iterate_marked
-    _format_entry = sacred.commands._format_entry
 
     module_configs = {}
     for k, module in parameters_to_module.items():
@@ -434,3 +433,27 @@ def _format_config_by_module(cfg, config_mods, parameters_to_module):
             lines.append(_format_entry(indent, entry))
 
     return "\n".join(lines)
+
+
+# sacred.commands._format_entry with colors removed
+def _format_entry(indent, entry):
+    import pprint
+
+    PRINTER = pprint.PrettyPrinter()
+    PRINTER.format = sacred.commands._non_unicode_repr
+
+    indent = " " * indent
+    if entry.key == "__doc__":
+        doc_string = entry.value.replace("\n", "\n" + indent)
+        assign = '{}"""{}"""'.format(indent, doc_string)
+    elif isinstance(entry, sacred.commands.ConfigEntry):
+        assign = indent + entry.key + " = " + PRINTER.pformat(entry.value)
+    else:  # isinstance(entry, PathEntry):
+        assign = indent + entry.key + ":"
+    if entry.doc:
+        doc_string = entry.doc
+        if len(assign) <= 35:
+            assign = "{:<35}  {}".format(assign, doc_string)
+        else:
+            assign += "    " + doc_string
+    return assign

--- a/capreolus/reranker/DSSM.py
+++ b/capreolus/reranker/DSSM.py
@@ -49,8 +49,9 @@ class DSSM(Reranker):
 
     @staticmethod
     def config():
-        # hidden layer dimentions, should be a list of space-separated number in a string, e.g. '56 128 32', the i-th value represents the output dim of the i-th hidden layer
+        # hidden layer sizes, like '56 128', where i'th value indicates output size of the i'th layer
         nhiddens = "56"
+
         lr = 0.0001
         return locals().copy()  # ignored by sacred
 

--- a/capreolus/reranker/DUET.py
+++ b/capreolus/reranker/DUET.py
@@ -153,7 +153,7 @@ class DUET(Reranker):
         activation = "relu"  # activation for ffw layers, shoule be either 'tanh' or 'relu'
 
         lr = 0.0001
-        dropoutrate = 0.5
+        dropoutrate = 0.5  # dropout probability
         return locals().copy()  # ignored by sacred
 
     @staticmethod

--- a/capreolus/reranker/DeepTileBar.py
+++ b/capreolus/reranker/DeepTileBar.py
@@ -176,10 +176,7 @@ class DeepTileBar(Reranker):
 
     @staticmethod
     def config():
-        # maxqlen = 4
         passagelen = 30
-        # ^ both hardcoded in tbcleanup.py
-        # l2regularise = True
         numberfilter = 3
         lstmhiddendim = 3
         linearhiddendim1 = 32

--- a/capreolus/reranker/HINT.py
+++ b/capreolus/reranker/HINT.py
@@ -330,11 +330,11 @@ class HINT(Reranker):
 
     @staticmethod
     def config():
-        # passagelen = 6
         spatialGRU = 2
         LSTMdim = 6
         kmax = 10
-        lr = 0.005  # 0.0005
+
+        lr = 0.005
         batch = 128
         return locals().copy()  # ignored by sacred
 

--- a/capreolus/reranker/PACRR.py
+++ b/capreolus/reranker/PACRR.py
@@ -95,7 +95,7 @@ class PACRR(Reranker):
         idf = True  # concatenate idf signals to combine relevance score from individual query terms
         kmax = 2  # value of kmax pooling used
         combine = 32  # size of combination layers
-        nonlinearity = "relu"
+        nonlinearity = "relu"  # nonlinearity in combination layer: 'none', 'relu', 'tanh'
         return locals().copy()  # ignored by sacred
 
     @staticmethod

--- a/capreolus/reranker/POSITDRMM.py
+++ b/capreolus/reranker/POSITDRMM.py
@@ -134,8 +134,6 @@ class POSITDRMM(Reranker):
 
     @staticmethod
     def config():
-        # passagelen = 6
-        # self.p["maxqlen"], EMBEDDING_DIM, BATCH_SIZE come from main config
         lr = 0.01
         return locals().copy()  # ignored by sacred
 

--- a/capreolus/searcher/bm25.py
+++ b/capreolus/searcher/bm25.py
@@ -34,8 +34,8 @@ class BM25Grid(Searcher):
 
     @staticmethod
     def config():
-        bmax = 1.0
-        k1max = 1.0
+        bmax = 1.0  # maximum b value to include in grid search (starting at 0.1)
+        k1max = 1.0  # maximum k1 value to include in grid search (starting at 0.1)
         return locals().copy()  # ignored by sacred
 
     def _query_index(self):
@@ -76,8 +76,8 @@ class BM25(Searcher):
 
     @staticmethod
     def config():
-        b = 0.4
-        k1 = 0.9
+        b = 0.4  # controls document length normalization
+        k1 = 0.9  # controls term saturation
         return locals().copy()  # ignored by sacred
 
     def _query_index(self):

--- a/capreolus/searcher/rm3.py
+++ b/capreolus/searcher/rm3.py
@@ -19,11 +19,11 @@ class BM25RM3(Searcher):
 
     @staticmethod
     def config():
-        b = 0.4
-        k1 = 0.9
-        ft = 10
-        fd = 10
-        ow = 0.5
+        b = 0.4  # BM25's b parameter
+        k1 = 0.9  # BM25's k1 parameter
+        ft = 10  # feedback terms to use with RM3
+        fd = 10  # feedback docs to use with RM3
+        ow = 0.5  # original query weight
         return locals().copy()  # ignored by sacred
 
     def _query_index(self):
@@ -74,12 +74,12 @@ class BM25RM3Grid(Searcher):
     @staticmethod
     def config():
         # pylint: disable=possibly-unused-variable
-        bmax = 1.0
-        k1max = 1.0
-        ftmax = 15
-        ftstep = 5
-        fdmax = 15
-        fdstep = 5
+        bmax = 1.0  # maximum b to include in grid search (BM25)
+        k1max = 1.0  # maximum k1 to include in grid search (BM25)
+        ftmax = 15  # maximum feedback terms to include in grid search (RM3)
+        ftstep = 5  # step size for feedback terms (RM3)
+        fdmax = 15  # maximum feedback docs in to include in grid search (RM3)
+        fdstep = 5  # step size for feedback docs (RM3)
         return locals().copy()  # ignored by sacred
 
     def _query_index(self):

--- a/capreolus/utils/common.py
+++ b/capreolus/utils/common.py
@@ -41,6 +41,7 @@ class Anserini:
 
         raise Exception("could not find anserini fat jar")
 
+
 def params_to_string(namekey, params, param_types, skip_check=False):
     params = {k: param_types[k](v) for k, v in params.items()}
     s = [params[namekey]]


### PR DESCRIPTION
This modifies sacred's `print_config` command to group config options by module, so that it is more clear which module each option is affecting. This also adds missing option descriptions and removes sacred's colors, which were hard to read and not working correctly. Closes #3.

Before:
```
Configuration (modified, added, typechanged, doc):
  b = 0.4
  batch = 32                         # batch size
  benchmark = 'robust04.title.wsdm20demo'
  collection = 'robust04'            # default modules
  datamode = 'unigram'               # DSSM requires trigram vector as input
...
```

After:
```
Configuration:
  benchmark = 'robust04.title.wsdm20demo'
    rundocsonly = True               use only docs from the searcher as pos/neg training instances (i.e., not all qrels)
  collection = 'robust04'            default modules
  experiment                           
    earlystopping = True
    expid = 'debug'                  experiment id/name
    fold = 's1'                      fold to use; indicates qids used for training, dev, and test sets
    predontrain = False              predict rankings on the training set
  index = 'anserini'
    indexstops = False               include stop words in index
    stemmer = 'none'                 stemmer to use: 'none', 'krovetz', 'porter'
...
```