### PR TITLE
Benchmark cleanup

### DIFF
--- a/capreolus/benchmark/__init__.py
+++ b/capreolus/benchmark/__init__.py
@@ -1,6 +1,5 @@
 from profane import import_all_modules
 
-# import_all_modules(__file__, __package__)
 
 import json
 import os
@@ -65,6 +64,8 @@ class DummyBenchmark(Benchmark):
 
 @Benchmark.register
 class WSDM20Demo(Benchmark):
+    """ Robust04 benchmark equivalent to robust04.yang19 """
+
     module_name = "wsdm20demo"
     dependencies = [Dependency(key="collection", module="collection", name="robust04")]
     qrel_file = PACKAGE_PATH / "data" / "qrels.robust2004.txt"
@@ -75,6 +76,12 @@ class WSDM20Demo(Benchmark):
 
 @Benchmark.register
 class Robust04Yang19(Benchmark):
+    """Robust04 benchmark using the folds from Yang et al. [1]
+
+    [1] Wei Yang, Kuang Lu, Peilin Yang, and Jimmy Lin. 2019. Critically Examining the "Neural Hype": Weak Baselines and the Additivity of Effectiveness Gains from Neural Ranking Models. SIGIR 2019.
+
+    """
+
     module_name = "robust04.yang19"
     dependencies = [Dependency(key="collection", module="collection", name="robust04")]
     qrel_file = PACKAGE_PATH / "data" / "qrels.robust2004.txt"
@@ -85,6 +92,11 @@ class Robust04Yang19(Benchmark):
 
 @Benchmark.register
 class ANTIQUE(Benchmark):
+    """A Non-factoid Question Answering Benchmark from Hashemi et al. [1]
+
+    [1] Helia Hashemi, Mohammad Aliannejadi, Hamed Zamani, and W. Bruce Croft. 2020. ANTIQUE: A non-factoid question answering benchmark. ECIR 2020.
+    """
+
     module_name = "antique"
     dependencies = [Dependency(key="collection", module="collection", name="antique")]
     qrel_file = PACKAGE_PATH / "data" / "qrels.antique.txt"
@@ -302,6 +314,8 @@ class CodeSearchNetChallenge(Benchmark):
 
 @Benchmark.register
 class COVID(Benchmark):
+    """ Ongoing TREC-COVID bechmark from https://ir.nist.gov/covidSubmit """
+
     module_name = "covid"
     dependencies = [Dependency(key="collection", module="collection", name="covid")]
     data_dir = PACKAGE_PATH / "data" / "covid"
@@ -319,9 +333,8 @@ class COVID(Benchmark):
         if self.config["round"] == self.lastest_round and not self.config["excludeknown"]:
             logger.warning(f"No evaluation can be done for the lastest round in exclude-known mode")
 
-        cfg_string = "_".join([f"{k}={v}" for k, v in self.config.items() if k != "name"])
-        data_dir = self.data_dir / cfg_string
-        data_dir.mkdir(exist_ok=True)
+        data_dir = self.get_cache_path() / "documents"
+        data_dir.mkdir(exist_ok=True, parents=True)
 
         self.qrel_ignore = f"{data_dir}/ignore.qrel.txt"
         self.qrel_file = f"{data_dir}/qrel.txt"
@@ -475,3 +488,6 @@ class CovidQA(Benchmark):
         json.dump({"s1": {"train_qids": all_qids, "predict": {"dev": all_qids, "test": all_qids}}}, open(self.fold_file, "w"))
         topic_f.close()
         qrel_f.close()
+
+
+import_all_modules(__file__, __package__)

--- a/capreolus/benchmark/robust04.py
+++ b/capreolus/benchmark/robust04.py
@@ -1,0 +1,21 @@
+from profane import ModuleBase, Dependency, ConfigOption, constants
+from . import Benchmark
+
+PACKAGE_PATH = constants["PACKAGE_PATH"]
+
+
+@Benchmark.register
+class Robust04(Benchmark):
+    """ Robust04 benchmark using the title folds from Huston and Croft. [1] Each of these is used as the test set.
+        Given the remaining four folds, we split them into the same train and dev sets used in recent work. [2]
+
+        [1] Samuel Huston and W. Bruce Croft. 2014. Parameters learned in the comparison of retrieval models using term dependencies. Technical Report.
+        [2] Sean MacAvaney, Andrew Yates, Arman Cohan, Nazli Goharian. 2019. CEDR: Contextualized Embeddings for Document Ranking. SIGIR 2019.
+    """
+
+    module_name = "robust04"
+    dependencies = [Dependency(key="collection", module="collection", name="robust04")]
+    qrel_file = PACKAGE_PATH / "data" / "qrels.robust2004.txt"
+    topic_file = PACKAGE_PATH / "data" / "topics.robust04.301-450.601-700.txt"
+    fold_file = PACKAGE_PATH / "data" / "rob04_cedr_folds.json"
+    query_type = "title"


### PR DESCRIPTION
- docstrings for robust04, ANTIQUE, and new robust04 with the standard Huston & Croft folds
- change COVID to download to the cache path, rather than Python package directory