### PR TITLE
Speed up EmbedText for similarity matrix construction

### DIFF
--- a/capreolus/extractor/common.py
+++ b/capreolus/extractor/common.py
@@ -1,0 +1,65 @@
+import numpy as np
+from pymagnitude import Magnitude, MagnitudeUtils
+
+from capreolus import constants, get_logger
+
+logger = get_logger(__name__)
+
+embedding_paths = {
+    "glove6b": "glove/light/glove.6B.300d",
+    "glove6b.50d": "glove/light/glove.6B.50d",
+    "w2vnews": "word2vec/light/GoogleNews-vectors-negative300",
+    "fasttext": "fasttext/light/wiki-news-300d-1M-subword",
+}
+
+pad_tok = "<pad>"
+
+
+def load_pretrained_embeddings(embedding_name):
+    if embedding_name not in embedding_paths:
+        raise ValueError(f"embedding name '{embedding_name}' is not a recognized embedding: {sorted(embedding_paths.keys())}")
+
+    embedding_cache = constants["CACHE_BASE_PATH"] / "embeddings"
+    numpy_cache = embedding_cache / (embedding_name + ".npy")
+    vocab_cache = embedding_cache / (embedding_name + ".vocab.txt")
+
+    if numpy_cache.exists() and vocab_cache.exists():
+        logger.debug("loading embeddings from %s", numpy_cache)
+        stoi, itos = load_vocab_file(vocab_cache)
+        embeddings = np.load(numpy_cache, mmap_mode="r").reshape(len(stoi), -1)
+
+        return embeddings, itos, stoi
+
+    logger.debug("preparing embeddings and vocab")
+    magnitude = Magnitude(MagnitudeUtils.download_model(embedding_paths[embedding_name], download_dir=embedding_cache))
+
+    terms, vectors = zip(*((term, vector) for term, vector in magnitude))
+    pad_vector = np.zeros(magnitude.dim, dtype=np.float32)
+    terms = [pad_tok] + list(terms)
+    vectors = np.array([pad_vector] + list(vectors), dtype=np.float32)
+    itos = {idx: term for idx, term in enumerate(terms)}
+
+    logger.debug("saving embeddings to %s", numpy_cache)
+    np.save(numpy_cache, vectors, allow_pickle=False)
+    save_vocab_file(itos, vocab_cache)
+    stoi = {s: i for i, s in itos.items()}
+
+    return vectors, itos, stoi
+
+
+def load_vocab_file(fn):
+    stoi, itos = {}, {}
+    with open(fn, "rt") as f:
+        for idx, line in enumerate(f):
+            term = line.strip()
+            stoi[term] = idx
+            itos[idx] = term
+
+    assert itos[0] == pad_tok
+    return stoi, itos
+
+
+def save_vocab_file(itos, fn):
+    with open(fn, "wt") as outf:
+        for idx, term in sorted(itos.items()):
+            print(term, file=outf)

--- a/capreolus/extractor/deeptileextractor.py
+++ b/capreolus/extractor/deeptileextractor.py
@@ -50,9 +50,9 @@ class DeepTileExtractor(Extractor):
         ConfigOption("tilechannels", 3),
         ConfigOption("embeddings", "glove6b"),
         ConfigOption("passagelen", 20),
-        ConfigOption("maxqlen", 8),
+        ConfigOption("maxqlen", 4),
         ConfigOption("maxdoclen", 800),
-        ConfigOption("usecache", False),
+        ConfigOption("usecache", True),
     ]
 
     def _get_pretrained_emb(self):

--- a/capreolus/reranker/CDSSM.py
+++ b/capreolus/reranker/CDSSM.py
@@ -78,6 +78,10 @@ class CDSSM(Reranker):
 
     module_name = "CDSSM"
 
+    dependencies = [
+        Dependency(key="extractor", module="extractor", name="slowembedtext"),
+        Dependency(key="trainer", module="trainer", name="pytorch"),
+    ]
     config_spec = [
         ConfigOption("nkernel", 3, "kernel dimension in conv"),
         ConfigOption("nfilter", 1, "number of filters in conv"),

--- a/capreolus/reranker/ConvKNRM.py
+++ b/capreolus/reranker/ConvKNRM.py
@@ -3,7 +3,7 @@ from torch import nn
 
 from capreolus import ConfigOption, Dependency
 from capreolus.reranker import Reranker
-from capreolus.reranker.common import RbfKernelBank, SimilarityMatrix, create_emb_layer
+from capreolus.reranker.common import RbfKernelBank, StackedSimilarityMatrix, create_emb_layer
 from capreolus.utils.loginit import get_logger
 
 logger = get_logger(__name__)  # pylint: disable=invalid-name
@@ -13,7 +13,7 @@ class ConvKNRM_class(nn.Module):
     def __init__(self, extractor, config):
         super(ConvKNRM_class, self).__init__()
         self.p = config
-        self.simmat = SimilarityMatrix(padding=extractor.pad)
+        self.simmat = StackedSimilarityMatrix(padding=extractor.pad)
         self.embeddings = create_emb_layer(extractor.embeddings, non_trainable=True)
 
         mus = [-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9, 1.0]
@@ -83,6 +83,10 @@ class ConvKNRM(Reranker):
 
     module_name = "ConvKNRM"
 
+    dependencies = [
+        Dependency(key="extractor", module="extractor", name="slowembedtext"),
+        Dependency(key="trainer", module="trainer", name="pytorch"),
+    ]
     config_spec = [
         ConfigOption("gradkernels", True, "backprop through mus and sigmas"),
         ConfigOption("maxngram", 3, "maximum ngram length considered"),

--- a/capreolus/reranker/DUET.py
+++ b/capreolus/reranker/DUET.py
@@ -20,8 +20,8 @@ class LocalModel(nn.Module):
         else:
             raise ValueError("Unexpected activation: should be either tanh or relu")
 
-        q_len, doc_len = p["trainer"]["maxqlen"], p["trainer"]["maxdoclen"]
-        dropoutrate = p["trainer"]["dropoutrate"]
+        q_len, doc_len = p["extractor"]["maxqlen"], p["extractor"]["maxdoclen"]
+        dropoutrate = p["dropoutrate"]
         self.conv = nn.Sequential(nn.Conv2d(1, p["nfilters"], (1, doc_len)), self.activation)  # (B, 1, Q, D) -> (B, H, Q, 1)
 
         self.ffw = nn.Sequential(
@@ -65,7 +65,7 @@ class DistributedModel(nn.Module):
 
         self.embedding = create_emb_layer(extractor.embeddings, non_trainable=True)
         embsize = self.embedding.weight.shape[-1]
-        dropoutrate = p["trainer"]["dropoutrate"]
+        dropoutrate = p["dropoutrate"]
 
         self.q_conv = nn.Sequential(
             nn.Conv2d(1, p["nfilters"], (3, embsize)),
@@ -135,11 +135,16 @@ class DUET(Reranker):
 
     module_name = "DUET"
 
+    dependencies = [
+        Dependency(key="extractor", module="extractor", name="slowembedtext"),
+        Dependency(key="trainer", module="trainer", name="pytorch"),
+    ]
     config_spec = [
-        ConfigOption("nfilter", 10, "number of filters for both local and distrbuted model"),
+        ConfigOption("nfilters", 10, "number of filters for both local and distrbuted model"),
         ConfigOption("lmhidden", 30, "ffw hidden layer dimension for local model"),
         ConfigOption("nhidden", 699, "ffw hidden layer dimension for local model"),
         ConfigOption("idfweight", True, "whether to weight each query word with its idf value in local model"),
+        ConfigOption("dropoutrate", 0.5, "dropout probability"),
         ConfigOption("activation", "relu", "ffw layer activation: tanh or relu"),
     ]
 

--- a/capreolus/reranker/HINT.py
+++ b/capreolus/reranker/HINT.py
@@ -327,6 +327,10 @@ class HINT(Reranker):
 
     module_name = "HINT"
 
+    dependencies = [
+        Dependency(key="extractor", module="extractor", name="slowembedtext"),
+        Dependency(key="trainer", module="trainer", name="pytorch"),
+    ]
     config_spec = [ConfigOption("spatialGRU", 2), ConfigOption("LSTMdim", 6), ConfigOption("kmax", 10)]
 
     def test(self, query_sentence, query_idf, pos_sentence, *args, **kwargs):

--- a/capreolus/reranker/POSITDRMM.py
+++ b/capreolus/reranker/POSITDRMM.py
@@ -130,6 +130,10 @@ class POSITDRMM(Reranker):
     """Ryan McDonald, George Brokos, and Ion Androutsopoulos. 2018. Deep Relevance Ranking Using Enhanced Document-Query Interactions. In EMNLP'18."""
 
     module_name = "POSITDRMM"
+    dependencies = [
+        Dependency(key="extractor", module="extractor", name="slowembedtext"),
+        Dependency(key="trainer", module="trainer", name="pytorch"),
+    ]
 
     def build_model(self):
         if not hasattr(self, "model"):

--- a/capreolus/reranker/TFKNRM.py
+++ b/capreolus/reranker/TFKNRM.py
@@ -65,7 +65,7 @@ class TFKNRM(Reranker):
     module_name = "TFKNRM"
 
     dependencies = [
-        Dependency(key="extractor", module="extractor", name="embedtext"),
+        Dependency(key="extractor", module="extractor", name="slowembedtext"),
         Dependency(key="trainer", module="trainer", name="tensorflow"),
     ]
     config_spec = [

--- a/capreolus/reranker/TK.py
+++ b/capreolus/reranker/TK.py
@@ -7,7 +7,7 @@ from allennlp.modules.matrix_attention import CosineMatrixAttention
 
 from capreolus import ConfigOption, Dependency
 from capreolus.reranker import Reranker
-from capreolus.reranker.common import SimilarityMatrix, create_emb_layer
+from capreolus.reranker.common import StackedSimilarityMatrix, create_emb_layer
 from capreolus.utils.loginit import get_logger
 
 logger = get_logger(__name__)  # pylint: disable=invalid-name
@@ -51,7 +51,7 @@ class TK_class(nn.Module):
         dropout = 0
         non_trainable = not self.p["finetune"]
         self.embedding = create_emb_layer(extractor.embeddings, non_trainable=non_trainable)
-        self.cosine_module = SimilarityMatrix(padding=extractor.pad)
+        self.cosine_module = StackedSimilarityMatrix(padding=extractor.pad)
 
         self.position_encoder = PositionalEncoding(self.embeddim)
         self.mixer = nn.Parameter(torch.full([1, 1, 1], 0.9, dtype=torch.float32, requires_grad=True))
@@ -150,6 +150,10 @@ class TK(Reranker):
 
     module_name = "TK"
 
+    dependencies = [
+        Dependency(key="extractor", module="extractor", name="slowembedtext"),
+        Dependency(key="trainer", module="trainer", name="pytorch"),
+    ]
     config_spec = [
         ConfigOption("gradkernels", True, "backprop through mus and sigmas"),
         ConfigOption("scoretanh", False, "use a tanh on the prediction as in paper (True) or do not use a nonlinearity (False)"),
@@ -157,7 +161,7 @@ class TK(Reranker):
         ConfigOption("projdim", 32),
         ConfigOption("ffdim", 100),
         ConfigOption("numlayers", 2),
-        ConfigOption("numattheads", 8),
+        ConfigOption("numattheads", 10),
         ConfigOption("alpha", 0.5),
         ConfigOption("usemask", False),
         ConfigOption("usemixer", False),

--- a/capreolus/reranker/tests/test_rerankers.py
+++ b/capreolus/reranker/tests/test_rerankers.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 from pymagnitude import Magnitude
@@ -8,6 +9,7 @@ from pymagnitude import Magnitude
 from capreolus import Reranker, module_registry
 from capreolus.benchmark import DummyBenchmark
 from capreolus.extractor.embedtext import EmbedText
+from capreolus.extractor.slowembedtext import SlowEmbedText
 from capreolus.extractor.bagofwords import BagOfWords
 from capreolus.extractor.deeptileextractor import DeepTileExtractor
 from capreolus.reranker.CDSSM import CDSSM
@@ -35,10 +37,12 @@ def test_reranker_creatable(tmpdir_as_cache, dummy_index, reranker_name):
 
 
 def test_knrm_pytorch(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
-    def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+    def fake_load_embeddings(self):
+        self.embeddings = np.zeros((1, 50))
+        self.stoi = {"<pad>": 0}
+        self.itos = {v: k for k, v in self.stoi.items()}
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(EmbedText, "_load_pretrained_embeddings", fake_load_embeddings)
 
     reranker = KNRM(
         {
@@ -71,7 +75,7 @@ def test_knrm_tf(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     reranker = TFKNRM(
         {"gradkernels": True, "finetune": False, "trainer": {"niters": 1, "itersize": 4, "batch": 2}},
@@ -95,10 +99,12 @@ def test_knrm_tf(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
 
 
 def test_pacrr(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
-    def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+    def fake_load_embeddings(self):
+        self.embeddings = np.zeros((1, 50))
+        self.stoi = {"<pad>": 0}
+        self.itos = {v: k for k, v in self.stoi.items()}
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(EmbedText, "_load_pretrained_embeddings", fake_load_embeddings)
 
     reranker = PACRR(
         {
@@ -129,11 +135,6 @@ def test_pacrr(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
 
 
 def test_dssm_unigram(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
-    def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
-
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
-
     reranker = DSSM({"nhiddens": "56", "trainer": {"niters": 1, "itersize": 4, "batch": 2}}, provide={"index": dummy_index})
     extractor = reranker.extractor
     metric = "map"
@@ -156,7 +157,7 @@ def test_tk(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     reranker = TK(
         {
@@ -196,7 +197,7 @@ def test_tk_get_mask(tmpdir, dummy_index, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     reranker = TK(
         {
@@ -300,7 +301,7 @@ def test_HINT(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     reranker = HINT(
         {"spatialGRU": 2, "LSTMdim": 6, "kmax": 10, "trainer": {"niters": 1, "itersize": 2, "batch": 1}},
@@ -327,7 +328,7 @@ def test_POSITDRMM(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     reranker = POSITDRMM({"trainer": {"niters": 1, "itersize": 4, "batch": 2}}, provide={"index": dummy_index})
     extractor = reranker.extractor
@@ -351,7 +352,7 @@ def test_CDSSM(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     reranker = CDSSM(
         {

--- a/capreolus/reranker/tests/test_rerankers.py
+++ b/capreolus/reranker/tests/test_rerankers.py
@@ -73,9 +73,9 @@ def test_knrm_pytorch(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
 
 def test_knrm_tf(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+        return np.zeros((1, 8), dtype=np.float32), {0: "<pad>"}, {"<pad>": 0}
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     reranker = TFKNRM(
         {"gradkernels": True, "finetune": False, "trainer": {"niters": 1, "itersize": 4, "batch": 2}},
@@ -155,9 +155,9 @@ def test_dssm_unigram(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
 
 def test_tk(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+        return np.zeros((1, 8), dtype=np.float32), {0: "<pad>"}, {"<pad>": 0}
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     reranker = TK(
         {
@@ -195,9 +195,9 @@ def test_tk(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
 
 def test_tk_get_mask(tmpdir, dummy_index, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+        return np.zeros((1, 8), dtype=np.float32), {0: "<pad>"}, {"<pad>": 0}
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     reranker = TK(
         {
@@ -299,9 +299,9 @@ def test_deeptilebars(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
 
 def test_HINT(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+        return np.zeros((1, 8), dtype=np.float32), {0: "<pad>"}, {"<pad>": 0}
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     reranker = HINT(
         {"spatialGRU": 2, "LSTMdim": 6, "kmax": 10, "trainer": {"niters": 1, "itersize": 2, "batch": 1}},
@@ -326,9 +326,9 @@ def test_HINT(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
 
 def test_POSITDRMM(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+        return np.zeros((1, 8), dtype=np.float32), {0: "<pad>"}, {"<pad>": 0}
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     reranker = POSITDRMM({"trainer": {"niters": 1, "itersize": 4, "batch": 2}}, provide={"index": dummy_index})
     extractor = reranker.extractor
@@ -350,9 +350,9 @@ def test_POSITDRMM(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
 
 def test_CDSSM(dummy_index, tmpdir, tmpdir_as_cache, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+        return np.zeros((1, 8), dtype=np.float32), {0: "<pad>"}, {"<pad>": 0}
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     reranker = CDSSM(
         {

--- a/capreolus/searcher/anserini.py
+++ b/capreolus/searcher/anserini.py
@@ -263,8 +263,9 @@ class StaticBM25RM3Rob04Yang19(Searcher):
         import shutil
 
         outfn = os.path.join(output_path, "static.run")
-        os.makedirs(output_path, exist_ok=True)
-        shutil.copy2(constants["PACKAGE_PATH"] / "data" / "rob04_yang19_rm3.run", outfn)
+        if not os.path.exists(outfn):
+            os.makedirs(output_path, exist_ok=True)
+            shutil.copy2(constants["PACKAGE_PATH"] / "data" / "rob04_yang19_rm3.run", outfn)
 
         return output_path
 

--- a/capreolus/tests/test_extractor.py
+++ b/capreolus/tests/test_extractor.py
@@ -11,7 +11,7 @@ from capreolus.collection import DummyCollection
 from capreolus.index import AnseriniIndex
 from capreolus.tokenizer import AnseriniTokenizer
 from capreolus.benchmark import DummyBenchmark
-from capreolus.extractor.embedtext import EmbedText
+from capreolus.extractor.slowembedtext import SlowEmbedText
 from capreolus.tests.common_fixtures import tmpdir_as_cache, dummy_index
 
 from capreolus.utils.exceptions import MissingDocError
@@ -30,17 +30,17 @@ def test_extractor_creatable(tmpdir_as_cache, dummy_index, extractor_name):
     extractor = Extractor.create(extractor_name, provide=provide)
 
 
-def test_embedtext_creation(monkeypatch):
+def test_slowembedtext_creation(monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     index_cfg = {"name": "anserini", "indexstops": False, "stemmer": "porter", "collection": {"name": "dummy"}}
     index = AnseriniIndex(index_cfg)
 
     extractor_cfg = {
-        "name": "embedtext",
+        "name": "slowembedtext",
         "embeddings": "glove6b",
         "zerounk": True,
         "calcidf": True,
@@ -48,7 +48,7 @@ def test_embedtext_creation(monkeypatch):
         "maxdoclen": MAXDOCLEN,
         "usecache": False,
     }
-    extractor = EmbedText(extractor_cfg, provide={"index": index})
+    extractor = SlowEmbedText(extractor_cfg, provide={"index": index})
     benchmark = DummyBenchmark()
 
     qids = list(benchmark.qrels.keys())  # ["301"]
@@ -69,14 +69,14 @@ def test_embedtext_creation(monkeypatch):
     return extractor
 
 
-def test_embedtext_id2vec(monkeypatch):
+def test_slowembedtext_id2vec(monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     extractor_cfg = {
-        "name": "embedtext",
+        "name": "slowembedtext",
         "embeddings": "glove6b",
         "zerounk": True,
         "calcidf": True,
@@ -84,7 +84,7 @@ def test_embedtext_id2vec(monkeypatch):
         "maxdoclen": MAXDOCLEN,
         "usecache": False,
     }
-    extractor = EmbedText(extractor_cfg, provide={"collection": DummyCollection()})
+    extractor = SlowEmbedText(extractor_cfg, provide={"collection": DummyCollection()})
     benchmark = DummyBenchmark()
 
     qids = list(benchmark.qrels.keys())  # ["301"]
@@ -123,14 +123,14 @@ def test_embedtext_id2vec(monkeypatch):
     assert error_thrown
 
 
-def test_embedtext_caching(dummy_index, monkeypatch):
+def test_slowembedtext_caching(dummy_index, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     extractor_cfg = {
-        "name": "embedtext",
+        "name": "slowembedtext",
         "embeddings": "glove6b",
         "zerounk": True,
         "calcidf": True,
@@ -138,7 +138,7 @@ def test_embedtext_caching(dummy_index, monkeypatch):
         "maxdoclen": MAXDOCLEN,
         "usecache": True,
     }
-    extractor = EmbedText(extractor_cfg, provide={"index": dummy_index})
+    extractor = SlowEmbedText(extractor_cfg, provide={"index": dummy_index})
     benchmark = DummyBenchmark()
 
     qids = list(benchmark.qrels.keys())  # ["301"]
@@ -151,7 +151,7 @@ def test_embedtext_caching(dummy_index, monkeypatch):
 
     assert extractor.is_state_cached(qids, docids)
 
-    new_extractor = EmbedText(extractor_cfg, provide={"index": dummy_index})
+    new_extractor = SlowEmbedText(extractor_cfg, provide={"index": dummy_index})
 
     assert new_extractor.is_state_cached(qids, docids)
     new_extractor._build_vocab(qids, docids, benchmark.topics[benchmark.query_type])
@@ -343,7 +343,7 @@ def test_bagofwords_caching(dummy_index, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(EmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
 
     extractor_cfg = {"name": "bagofwords", "datamode": "trigram", "maxqlen": 4, "maxdoclen": 800, "usecache": True}
     extractor = BagOfWords(extractor_cfg, provide={"index": dummy_index})

--- a/capreolus/tests/test_extractor.py
+++ b/capreolus/tests/test_extractor.py
@@ -83,9 +83,9 @@ def test_embedtext_id2vec(monkeypatch):
 
 def test_slowembedtext_creation(monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+        return np.zeros((1, 8), dtype=np.float32), {0: "<pad>"}, {"<pad>": 0}
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     index_cfg = {"name": "anserini", "indexstops": False, "stemmer": "porter", "collection": {"name": "dummy"}}
     index = AnseriniIndex(index_cfg)
@@ -122,9 +122,9 @@ def test_slowembedtext_creation(monkeypatch):
 
 def test_slowembedtext_id2vec(monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+        return np.zeros((1, 8), dtype=np.float32), {0: "<pad>"}, {"<pad>": 0}
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     extractor_cfg = {
         "name": "slowembedtext",
@@ -176,9 +176,9 @@ def test_slowembedtext_id2vec(monkeypatch):
 
 def test_slowembedtext_caching(dummy_index, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
-        return Magnitude(None)
+        return np.zeros((1, 8), dtype=np.float32), {0: "<pad>"}, {"<pad>": 0}
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     extractor_cfg = {
         "name": "slowembedtext",
@@ -394,7 +394,7 @@ def test_bagofwords_caching(dummy_index, monkeypatch):
     def fake_magnitude_embedding(*args, **kwargs):
         return Magnitude(None)
 
-    monkeypatch.setattr(SlowEmbedText, "_get_pretrained_emb", fake_magnitude_embedding)
+    monkeypatch.setattr(SlowEmbedText, "_load_pretrained_embeddings", fake_magnitude_embedding)
 
     extractor_cfg = {"name": "bagofwords", "datamode": "trigram", "maxqlen": 4, "maxdoclen": 800, "usecache": True}
     extractor = BagOfWords(extractor_cfg, provide={"index": dummy_index})


### PR DESCRIPTION
- Rename `SimilarityMatrix` to `StackedSimilarityMatrix`, which is intended for use with multiple channels (eg BERT layers)
- Add new `SimilarityMatrix` class that accepts negative indices for OOV terms. Cosine embedding similarity is used for positive indices, while negative indices are exact matched. 
- Rename existing `EmbedText` extractor to `SlowEmbedText`
- Add a new `EmbedText` extractor that produces output suitable for new `SimilarityMatrix` class. This is much more efficient, because we do not need to generate embeddings for OOV terms. Switch rerankers that use static embeddings (DRMM*, KNRM, PACRR) to use new extractor by default.

Closes #63 .