### PR TITLE
PARADE support for loading BERT/ELECTRA models from MS MARCO checkpoints

### DIFF
--- a/capreolus/extractor/bertpassage.py
+++ b/capreolus/extractor/bertpassage.py
@@ -53,6 +53,7 @@ class BertPassage(Extractor):
 
     def load_state(self, qids, docids):
         cache_fn = self.get_state_cache_file_path(qids, docids)
+        logger.debug("loading state from: %s", cache_fn)
         with open(cache_fn, "rb") as f:
             state_dict = pickle.load(f)
             self.qid2toks = state_dict["qid2toks"]

--- a/capreolus/reranker/TFBERTMaxP.py
+++ b/capreolus/reranker/TFBERTMaxP.py
@@ -1,15 +1,41 @@
 import tensorflow as tf
-from transformers import TFBertForSequenceClassification
+from transformers import TFAutoModelForSequenceClassification
 
 from capreolus import ConfigOption, Dependency
 from capreolus.reranker import Reranker
+
+class TFElectraRelevanceHead(tf.keras.layers.Layer):
+    """ BERT-style ClassificationHead (i.e., out_proj only -- no dense). See transformers.TFElectraClassificationHead """
+
+    def __init__(self, dropout, out_proj, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dropout = dropout
+        self.out_proj = out_proj
+
+    def call(self, inputs, **kwargs):
+        x = inputs[:, 0, :]  # take <s> token (equiv. to [CLS])
+        x = self.dropout(x)
+        x = self.out_proj(x)
+        return x
 
 
 class TFBERTMaxP_Class(tf.keras.layers.Layer):
     def __init__(self, extractor, config, *args, **kwargs):
         super(TFBERTMaxP_Class, self).__init__(*args, **kwargs)
         self.extractor = extractor
-        self.bert = TFBertForSequenceClassification.from_pretrained(config["pretrained"], hidden_dropout_prob=0.1)
+
+        if config["pretrained"] == "electra-base-msmarco":
+            self.bert = TFAutoModelForSequenceClassification.from_pretrained("Capreolus/electra-base-msmarco")
+            dropout, fc = self.bert.classifier.dropout, self.bert.classifier.out_proj
+            self.bert.classifier = TFElectraRelevanceHead(dropout, fc)
+        elif config["pretrained"] == "bert-base-msmarco":
+            self.bert = TFAutoModelForSequenceClassification.from_pretrained("Capreolus/bert-base-msmarco")
+        elif config["pretrained"] == "bert-base-uncased":
+            self.bert = TFAutoModelForSequenceClassification.from_pretrained(config["pretrained"], hidden_dropout_prob=0.1)
+        else:
+            raise ValueError(f"unsupported model: {config['pretrained']}; need to ensure correct tokenizers will be used before arbitrary hgf models are supported")
+
+        
         self.config = config
 
     def call(self, x, **kwargs):
@@ -72,7 +98,7 @@ class TFBERTMaxP(Reranker):
         Dependency(key="trainer", module="trainer", name="tensorflow"),
     ]
     config_spec = [
-        ConfigOption("pretrained", "bert-base-uncased", "Hugging face transformer pretrained model"),
+        ConfigOption("pretrained", "bert-base-uncased", "Pretrained model: bert-base-uncased, bert-base-msmarco, or electra-base-msmarco")
         ConfigOption("aggregation", "max"),
     ]
 

--- a/capreolus/reranker/TFBERTMaxP.py
+++ b/capreolus/reranker/TFBERTMaxP.py
@@ -4,6 +4,7 @@ from transformers import TFAutoModelForSequenceClassification
 from capreolus import ConfigOption, Dependency
 from capreolus.reranker import Reranker
 
+
 class TFElectraRelevanceHead(tf.keras.layers.Layer):
     """ BERT-style ClassificationHead (i.e., out_proj only -- no dense). See transformers.TFElectraClassificationHead """
 
@@ -33,9 +34,10 @@ class TFBERTMaxP_Class(tf.keras.layers.Layer):
         elif config["pretrained"] == "bert-base-uncased":
             self.bert = TFAutoModelForSequenceClassification.from_pretrained(config["pretrained"], hidden_dropout_prob=0.1)
         else:
-            raise ValueError(f"unsupported model: {config['pretrained']}; need to ensure correct tokenizers will be used before arbitrary hgf models are supported")
+            raise ValueError(
+                f"unsupported model: {config['pretrained']}; need to ensure correct tokenizers will be used before arbitrary hgf models are supported"
+            )
 
-        
         self.config = config
 
     def call(self, x, **kwargs):
@@ -98,7 +100,9 @@ class TFBERTMaxP(Reranker):
         Dependency(key="trainer", module="trainer", name="tensorflow"),
     ]
     config_spec = [
-        ConfigOption("pretrained", "bert-base-uncased", "Pretrained model: bert-base-uncased, bert-base-msmarco, or electra-base-msmarco")
+        ConfigOption(
+            "pretrained", "bert-base-uncased", "Pretrained model: bert-base-uncased, bert-base-msmarco, or electra-base-msmarco"
+        ),
         ConfigOption("aggregation", "max"),
     ]
 

--- a/capreolus/reranker/parade.py
+++ b/capreolus/reranker/parade.py
@@ -11,7 +11,16 @@ class TFParade_Class(tf.keras.layers.Layer):
         super(TFParade_Class, self).__init__(*args, **kwargs)
         self.extractor = extractor
         self.config = config
-        self.bert = TFBertModel.from_pretrained("bert-base-uncased")
+
+        if config["pretrained"] == "electra-base-msmarco":
+            self.bert = TFElectraModel.from_pretrained("Capreolus/bert-electra-msmarco")
+        elif config["pretrained"] == "bert-base-msmarco":
+            self.bert = TFBertModel.from_pretrained("Capreolus/bert-base-msmarco")
+        elif config["pretrained"] == "bert-base-uncased":
+            self.bert = TFBertModel.from_pretrained("bert-base-uncased")
+        else:
+            raise ValueError(f"unsupported model: {config['pretrained']}; need to ensure correct tokenizers will be used before arbitrary hgf models are supported")
+
         self.transformer_layer_1 = TFBertLayer(self.bert.config)
         self.transformer_layer_2 = TFBertLayer(self.bert.config)
         self.num_passages = extractor.config["numpassages"]
@@ -102,7 +111,7 @@ class TFParade(Reranker):
         Dependency(key="trainer", module="trainer", name="tensorflow"),
     ]
     config_spec = [
-        ConfigOption("pretrained", "bert-base-uncased", "Hugging face transformer pretrained model"),
+        ConfigOption("pretrained", "bert-base-uncased", "Pretrained model: bert-base-uncased, bert-base-msmarco, or electra-base-msmarco")
         ConfigOption("aggregation", "maxp"),
     ]
 

--- a/capreolus/reranker/parade.py
+++ b/capreolus/reranker/parade.py
@@ -13,13 +13,15 @@ class TFParade_Class(tf.keras.layers.Layer):
         self.config = config
 
         if config["pretrained"] == "electra-base-msmarco":
-            self.bert = TFElectraModel.from_pretrained("Capreolus/bert-electra-msmarco")
+            self.bert = TFElectraModel.from_pretrained("Capreolus/electra-base-msmarco")
         elif config["pretrained"] == "bert-base-msmarco":
             self.bert = TFBertModel.from_pretrained("Capreolus/bert-base-msmarco")
         elif config["pretrained"] == "bert-base-uncased":
             self.bert = TFBertModel.from_pretrained("bert-base-uncased")
         else:
-            raise ValueError(f"unsupported model: {config['pretrained']}; need to ensure correct tokenizers will be used before arbitrary hgf models are supported")
+            raise ValueError(
+                f"unsupported model: {config['pretrained']}; need to ensure correct tokenizers will be used before arbitrary hgf models are supported"
+            )
 
         self.transformer_layer_1 = TFBertLayer(self.bert.config)
         self.transformer_layer_2 = TFBertLayer(self.bert.config)
@@ -111,7 +113,9 @@ class TFParade(Reranker):
         Dependency(key="trainer", module="trainer", name="tensorflow"),
     ]
     config_spec = [
-        ConfigOption("pretrained", "bert-base-uncased", "Pretrained model: bert-base-uncased, bert-base-msmarco, or electra-base-msmarco")
+        ConfigOption(
+            "pretrained", "bert-base-uncased", "Pretrained model: bert-base-uncased, bert-base-msmarco, or electra-base-msmarco"
+        ),
         ConfigOption("aggregation", "maxp"),
     ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,8 @@ scispacy
 spacy
 pandas
 https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_core_sci_lg-0.2.4.tar.gz
+# deps that the pymagnitude package isn't pulling in:
+lz4
+xxhash
+annoy
+fasteners


### PR DESCRIPTION
This adds config options for loading BERT and ELECTRA-Base models (from hgf model hub) that have been fine-tuned on the MS MARCO passage collection. 