### PR TITLE
Force qids in folds to be strings

### DIFF
--- a/capreolus/benchmark/__init__.py
+++ b/capreolus/benchmark/__init__.py
@@ -38,7 +38,7 @@ class Benchmark(ModuleBase):
     @property
     def folds(self):
         if not hasattr(self, "_folds"):
-            self._folds = json.load(open(self.fold_file, "rt"))
+            self._folds = json.load(open(self.fold_file, "rt"), parse_int=str)
         return self._folds
 
 


### PR DESCRIPTION
When parsing qrel files, we don't enforce that the QIDs are integers. This means that they need to be strings in a `folds.json` file as well; storing them as integers was causing a mismatch. This PR ensures they're stored as strings.