### PR TITLE
Config option for separate DataLoader thread

### DIFF
--- a/docs/quick.md
+++ b/docs/quick.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-- Requirements: Python 3.6+, a Python environment you can install packages in (e.g., `virtualenv`), and Java 11. See the [detailed installation instructions](installation) for help with these.
+- Requirements: Python 3.7+, a Python environment you can install packages in (e.g., a [Conda environment](https://gist.github.com/andrewyates/970c570411c4a36785f6c0e9362eb1eb)), and Java 11. See the [detailed installation instructions](installation) for help with these.
 - Install: `pip install capreolus`
 
 ```eval_rst


### PR DESCRIPTION
Setting PyTorch DataLoader's `num_workers=1` causes DataLoader to run in a separate thread and is faster. However, this seems to cause deadlock in many Python environments, including Colab. Anaconda suffers from the same issue, but Miniconda does not, which suggests it's due to some other package (which is part of the default Anaconda environment). This seems to be a difficult bug with PyTorch issues mentioning it going back to 2017.

This PR adds a `trainer.multithreaded` option to PytorchTrainer that defaults to False to avoid this issue. When running intensive experiments, it's best to set`trainer.multithreaded=True`, which restores the previous behavior of setting DataLoader's `num_workers=1`.