### PR TITLE
PredSampler keeps empty qids

### DIFF
--- a/capreolus/sampler/__init__.py
+++ b/capreolus/sampler/__init__.py
@@ -43,15 +43,6 @@ class Sampler(ModuleBase):
         self.total_samples = 0
         self.clean()
 
-    def clean(self):
-        total_samples = 0  # keep tracks of the total possible number of unique training triples for this dataset
-        for qid in list(self.qid_to_docids.keys()):
-            posdocs = len(self.qid_to_reldocs[qid])
-            negdocs = len(self.qid_to_negdocs[qid])
-            total_samples += posdocs * negdocs
-
-        self.total_samples = total_samples
-
     def get_hash(self):
         raise NotImplementedError
 
@@ -195,6 +186,15 @@ class PredSampler(Sampler, torch.utils.data.IterableDataset):
                     # when predictiong we raise an exception on missing docs, as this may invalidate results
                     logger.error("got none features for prediction: qid=%s posid=%s", qid, docid)
                     raise
+
+    def clean(self):
+        total_samples = 0  # keep tracks of the total possible number of unique training triples for this dataset
+        for qid in list(self.qid_to_docids.keys()):
+            posdocs = len(self.qid_to_reldocs[qid])
+            negdocs = len(self.qid_to_negdocs[qid])
+            total_samples += posdocs * negdocs
+
+        self.total_samples = total_samples
 
     def __hash__(self):
         return self.get_hash()

--- a/capreolus/sampler/__init__.py
+++ b/capreolus/sampler/__init__.py
@@ -70,7 +70,7 @@ class TrainingSamplerMixin:
             posdocs = len(self.qid_to_reldocs[qid])
             negdocs = len(self.qid_to_negdocs[qid])
             if posdocs == 0 or negdocs == 0:
-                logger.debug("removing training qid=%s with %s positive docs and %s negative docs", qid, posdocs, negdocs)
+                logger.warning("removing training qid=%s with %s positive docs and %s negative docs", qid, posdocs, negdocs)
                 del self.qid_to_reldocs[qid]
                 del self.qid_to_docids[qid]
                 del self.qid_to_negdocs[qid]


### PR DESCRIPTION
Fixes a regression causing PredSampler to skip over qids with no relevant documents found by the first stage ranker. This potentially affects the evaluation results Capreolus outputs, but not those obtained using `trec_eval` on the run files.