### PR TITLE
[ignore] Pytorch supports PARADE, AMP, and LR scheduler

### DIFF
--- a/capreolus/reranker/ptparade.py
+++ b/capreolus/reranker/ptparade.py
@@ -53,7 +53,7 @@ class PTParade_Class(nn.Module):
         batch_size = expanded_cls.shape[0]
         tiled_initial_cls = self.initial_cls_embedding.repeat(batch_size, 1)
         merged_cls = torch.cat((tiled_initial_cls.view(batch_size, 1, self.bert.config.hidden_size), expanded_cls), dim=1)
-        merged_cls += self.full_position_embeddings
+        merged_cls = merged_cls + self.full_position_embeddings
 
         (transformer_out_1,) = self.transformer_layer_1(merged_cls, None, None, None)
         (transformer_out_2,) = self.transformer_layer_2(transformer_out_1, None, None, None)

--- a/capreolus/reranker/ptparade.py
+++ b/capreolus/reranker/ptparade.py
@@ -1,0 +1,111 @@
+import torch
+from torch import nn
+from transformers import BertModel, ElectraModel
+from transformers.modeling_bert import BertLayer
+
+from capreolus import ConfigOption, Dependency
+from capreolus.reranker import Reranker
+
+
+class PTParade_Class(nn.Module):
+    def __init__(self, extractor, config, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.extractor = extractor
+        self.config = config
+
+        if config["pretrained"] == "electra-base-msmarco":
+            self.bert = ElectraModel.from_pretrained("Capreolus/electra-base-msmarco")
+        elif config["pretrained"] == "bert-base-msmarco":
+            self.bert = BertModel.from_pretrained("Capreolus/bert-base-msmarco")
+        elif config["pretrained"] == "bert-base-uncased":
+            self.bert = BertModel.from_pretrained("bert-base-uncased")
+        else:
+            raise ValueError(
+                f"unsupported model: {config['pretrained']}; need to ensure correct tokenizers will be used before arbitrary hgf models are supported"
+            )
+
+        self.transformer_layer_1 = BertLayer(self.bert.config)
+        self.transformer_layer_2 = BertLayer(self.bert.config)
+        self.num_passages = extractor.config["numpassages"]
+        self.maxseqlen = extractor.config["maxseqlen"]
+        self.linear = nn.Linear(self.bert.config.hidden_size, 1)
+
+        if config["aggregation"] == "maxp":
+            raise NotImplementedError()
+        elif config["aggregation"] == "transformer":
+            self.aggregation = self.aggregate_using_transformer
+            input_embeddings = self.bert.get_input_embeddings()
+            cls_token_id = torch.tensor([[101]])
+            self.initial_cls_embedding = input_embeddings(cls_token_id).view(1, self.bert.config.hidden_size)
+            self.full_position_embeddings = torch.zeros(
+                (1, self.num_passages + 1, self.bert.config.hidden_size), requires_grad=True, dtype=torch.float
+            )
+            torch.nn.init.normal_(self.full_position_embeddings, mean=0.0, std=0.02)
+
+            self.initial_cls_embedding = nn.Parameter(self.initial_cls_embedding, requires_grad=True)
+            self.full_position_embeddings = nn.Parameter(self.full_position_embeddings, requires_grad=True)
+        else:
+            raise NotImplementedError()
+
+    def aggregate_using_transformer(self, cls):
+        expanded_cls = cls.view(-1, self.num_passages, self.bert.config.hidden_size)
+        # TODO make sure batch size here is correct
+        batch_size = expanded_cls.shape[0]
+        tiled_initial_cls = self.initial_cls_embedding.repeat(batch_size, 1)
+        merged_cls = torch.cat((tiled_initial_cls.view(batch_size, 1, self.bert.config.hidden_size), expanded_cls), dim=1)
+        merged_cls += self.full_position_embeddings
+
+        (transformer_out_1,) = self.transformer_layer_1(merged_cls, None, None, None)
+        (transformer_out_2,) = self.transformer_layer_2(transformer_out_1, None, None, None)
+
+        aggregated = transformer_out_2[:, 0, :]
+        return aggregated
+
+    def forward(self, doc_input, doc_mask, doc_seg):
+        batch_size = doc_input.shape[0]
+        doc_input = doc_input.view((batch_size * self.num_passages, self.maxseqlen))
+        doc_mask = doc_mask.view((batch_size * self.num_passages, self.maxseqlen))
+        doc_seg = doc_seg.view((batch_size * self.num_passages, self.maxseqlen))
+
+        cls = self.bert(doc_input, attention_mask=doc_mask, token_type_ids=doc_seg)[0][:, 0, :]
+        aggregated = self.aggregation(cls)
+
+        return self.linear(aggregated)
+
+
+@Reranker.register
+class PTParade(Reranker):
+    """
+    PyTorch implementation of PARADE.
+
+    PARADE: Passage Representation Aggregation for Document Reranking.
+    Canjia Li, Andrew Yates, Sean MacAvaney, Ben He, and Yingfei Sun. arXiv 2020.
+    https://arxiv.org/pdf/2008.09093.pdf
+    """
+
+    module_name = "ptparade"
+
+    dependencies = [
+        Dependency(key="extractor", module="extractor", name="pooledbertpassage"),
+        Dependency(key="trainer", module="trainer", name="pytorch"),
+    ]
+    config_spec = [
+        ConfigOption(
+            "pretrained", "bert-base-uncased", "Pretrained model: bert-base-uncased, bert-base-msmarco, or electra-base-msmarco"
+        ),
+        ConfigOption("aggregation", "transformer"),
+    ]
+
+    def build_model(self):
+        if not hasattr(self, "model"):
+            self.model = PTParade_Class(self.extractor, self.config)
+        return self.model
+
+    def score(self, d):
+        return [
+            self.model(d["pos_bert_input"], d["pos_mask"], d["pos_seg"]).view(-1),
+            self.model(d["neg_bert_input"], d["neg_mask"], d["neg_seg"]).view(-1),
+        ]
+
+    def test(self, d):
+        return self.model(d["pos_bert_input"], d["pos_mask"], d["pos_seg"]).view(-1)

--- a/capreolus/sampler/__init__.py
+++ b/capreolus/sampler/__init__.py
@@ -225,3 +225,8 @@ class PredSampler(Sampler, torch.utils.data.IterableDataset):
         for qid in self.qid_to_docids:
             for docid in self.qid_to_docids[qid]:
                 yield qid, docid
+
+
+from profane import import_all_modules
+
+import_all_modules(__file__, __package__)

--- a/capreolus/sampler/__init__.py
+++ b/capreolus/sampler/__init__.py
@@ -1,5 +1,6 @@
 import hashlib
 
+import numpy as np
 import torch.utils.data
 
 from capreolus import ModuleBase, Dependency, ConfigOption, constants
@@ -70,6 +71,22 @@ class TrainingSamplerMixin:
 
         self.total_samples = total_samples
 
+    def __iter__(self):
+        # when running in a worker, the sampler will be recreated several times with same seed,
+        # so we combine worker_info's seed (which varies across obj creations) with our original seed
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is not None:
+            # avoid reseeding the same way multiple times in case DataLoader's behavior changes
+            if not hasattr(self, "_last_worker_seed"):
+                self._last_worker_seed = None
+
+            if self._last_worker_seed is None or self._last_worker_seed != worker_info.seed:
+                seeds = [self.config["seed"], worker_info.seed]
+                self.rng = np.random.Generator(np.random.PCG64(seeds))
+                self._last_worker_seed = worker_info.seed
+
+        return iter(self.generate_samples())
+
 
 @Sampler.register
 class TrainTripletSampler(Sampler, TrainingSamplerMixin, torch.utils.data.IterableDataset):
@@ -113,13 +130,6 @@ class TrainTripletSampler(Sampler, TrainingSamplerMixin, torch.utils.data.Iterab
                         "skipping training pair with missing features: qid=%s posid=%s negid=%s", qid, posdocid, negdocid
                     )
 
-    def __iter__(self):
-        """
-        Returns: Triplets of the form (query_feature, posdoc_feature, negdoc_feature)
-        """
-
-        return iter(self.generate_samples())
-
 
 @Sampler.register
 class TrainPairSampler(Sampler, TrainingSamplerMixin, torch.utils.data.IterableDataset):
@@ -143,8 +153,6 @@ class TrainPairSampler(Sampler, TrainingSamplerMixin, torch.utils.data.IterableD
             raise RuntimeError("TrainDataset has no valid training pairs")
 
         while True:
-            # TODO: two documents does not necessarily come from same query
-            # ^ Why?
             self.rng.shuffle(all_qids)
             for qid in all_qids:
                 # Convention for label - [1, 0] indicates that doc belongs to class 1 (i.e relevant
@@ -153,9 +161,9 @@ class TrainPairSampler(Sampler, TrainingSamplerMixin, torch.utils.data.IterableD
                     yield self.extractor.id2vec(qid, docid, negid=None, label=[0, 1])
                 for docid in self.qid_to_negdocs[qid]:
                     yield self.extractor.id2vec(qid, docid, negid=None, label=[1, 0])
-
-    def __iter__(self):
-        return iter(self.generate_samples())
+                # REF-TODO returning all docs in a row does not make sense w/ pytorch
+                #          (with TF the dataset itself is shuffled, so this is okay)
+                # REF-TODO make sure always negid empty is ok
 
 
 @Sampler.register

--- a/capreolus/trainer/__init__.py
+++ b/capreolus/trainer/__init__.py
@@ -29,6 +29,23 @@ class Trainer(ModuleBase):
 
         return dev_best_weight_fn, weights_output_path, info_output_path, loss_fn
 
+    def change_lr(self, epoch, lr):
+        """
+        Apply warm up or decay depending on the current epoch
+        """
+        return lr * self.lr_multiplier(epoch)
+
+    def lr_multiplier(self, epoch):
+        warmup_steps = self.config["warmupsteps"]
+        if warmup_steps and epoch <= warmup_steps:
+            return min((epoch + 1) / warmup_steps, 1)
+        elif self.config["decaytype"] == "exponential":
+            return self.config["decay"] ** ((epoch - warmup_steps) / self.config["decaystep"])
+        elif self.config["decaytype"] == "linear":
+            return 1 / (1 + self.config["decay"] * epoch)
+
+        return 1
+
 
 from profane import import_all_modules
 


### PR DESCRIPTION
- Ports PARADE (transformer) model to Pytorch. Other variants not yet supported.
- Adds LR scheduling config options to Pytorch mirroring TF's.
- Adds AMP support to Pytorch
- Fixes seeding bug when enabling Pytorch multithreading
- Pytorch saves weights from every epoch only when fastforwarding is enabled (best dev weights always saved)

Closes #86 and closes #87.