### PR TITLE
[WIP] Feature/msmarco psg

### DIFF
--- a/capreolus/benchmark/msmarco.py
+++ b/capreolus/benchmark/msmarco.py
@@ -1,14 +1,103 @@
-from capreolus import constants
+import os
+import math
+import gzip
+import json
+import random
+
+from capreolus import constants, ConfigOption, Dependency, constants
+from capreolus.utils.common import download_file, remove_newline
+from capreolus.utils.trec import topic_to_trectxt, load_trec_topics
+from capreolus.utils.loginit import get_logger
+
+logger = get_logger(__name__)
 
 PACKAGE_PATH = constants["PACKAGE_PATH"]
+from . import Benchmark
 
 
-# TODO add download_if_missing and re-enable
-# @Benchmark.register
-# class MSMarcoPassage(Benchmark):
-#     module_name = "msmarcopassage"
-#     dependencies = [Dependency(key="collection", module="collection", name="msmarco")]
-#     qrel_file = PACKAGE_PATH / "data" / "qrels.msmarcopassage.txt"
-#     topic_file = PACKAGE_PATH / "data" / "topics.msmarcopassage.txt"
-#     fold_file = PACKAGE_PATH / "data" / "msmarcopassage.folds.json"
-#     query_type = "title"
+@Benchmark.register
+class MSMarcoPassage(Benchmark):
+    module_name = "msmarcopsg"
+    dependencies = [Dependency(key="collection", module="collection", name="msmarcopsg")]
+
+    query_type = "title"
+    config_spec = []
+    data_dir = PACKAGE_PATH / "data" / "msmarcopsg"
+    qrel_file = data_dir / "qrels.msmarcodoc.txt"
+    topic_file = data_dir / "topics.msmarcodoc.txt"
+    fold_file = data_dir / "msmarcodoc.folds.json"
+
+    def build(self):
+        self.download_if_missing()
+
+    def download_if_missing(self):
+        self.data_dir.mkdir(exist_ok=True, parents=True)
+        if all([f.exists() for f in [self.qrel_file, self.topic_file, self.fold_file]]):
+            return
+
+        def match_size(fn):
+            if ".train." in fn:
+                return True
+
+            # if self.config["qrelsize"] == "small":
+            if True:
+                return ".small." in fn
+            return ".small." not in fn
+
+        gz_dir = self.collection.download_raw()
+        queries_fn = [fn for fn in os.listdir(gz_dir) if "queries." in fn and match_size(fn)]
+        qrels_fn = [fn for fn in os.listdir(gz_dir) if "qrels." in fn and match_size(fn)]  # note that qrel.test is not given
+
+        # topic and qrel
+        topic_f, qrel_f = open(self.topic_file, "w"), open(self.qrel_file, "w")
+        folds = {"train": set(), "dev": set(), "eval": set()}
+
+        for set_name in folds:
+            cur_queriesfn = [fn for fn in queries_fn if f".{set_name}." in fn]
+            cur_qrelfn = [fn for fn in qrels_fn if f".{set_name}." in fn]
+            with open(gz_dir / cur_queriesfn[0], "r") as f:
+                for line in f:
+                    qid, query = line.strip().split("\t")
+                    topic_f.write(topic_to_trectxt(qid, query))
+                    folds[set_name].add(qid)
+
+            if not cur_qrelfn:
+                logger.warning(f"{set_name} qrel is unfound. This is expected if it is eval set. "
+                               f"This is unexpected if it is train or dev set.")
+                continue
+
+            with open(gz_dir / cur_qrelfn[0], "r") as f:
+                for line in f:
+                    qrel_f.write(line)
+
+        # fold
+        folds = {k: list(v) for k, v in folds.items()}
+        folds = {"s1": {"train_qids": folds["train"], "predict": {"dev": folds["dev"], "test": folds["dev"]}}}
+        json.dump(folds, open(self.fold_file, "w"))
+
+
+class MSMarcoPassageKeywords(MSMarcoPassage):
+    module_name = "msmarcopsg_keywords"
+    dependencies = MSMarcoPassage.dependencies + [
+        Dependency(
+            key="tokenizer",
+            module="tokenizer",
+            name="anserini",
+            default_config_overrides={"indexstops": False, "stemmer": "none"},  # don't keepStops, don't stem
+        ),
+    ]
+
+    topic_file = MSMarcoPassage.data_dir / "topics.msmarcodoc.keyword.txt"
+
+    def download_if_missing(self):
+        super().download_if_missing()
+        full_topic_file = super().topic_file
+        assert full_topic_file.exists()
+        if self.topic_file.exists():
+            return
+
+        title = load_trec_topics(full_topic_file)["title"]
+        with open(self.topic_file, "w") as f:
+            for qid, full_topic in title:
+                kw_topic = self.tokenizer.tokenize(full_topic)
+                f.write(topic_to_trectxt(qid, kw_topic))

--- a/capreolus/collection/msmarco.py
+++ b/capreolus/collection/msmarco.py
@@ -1,7 +1,82 @@
-# @Collection.register
-# class MSMarco(Collection):
-#     module_name = "msmarco"
-#     config_keys_not_in_path = ["path"]
-#     collection_type = "TrecCollection"
-#     generator_type = "DefaultLuceneDocumentGenerator"
-#     config_spec = [ConfigOption("path", "/GW/NeuralIR/nobackup/msmarco/trec_format", "path to corpus")]
+import os
+import gzip
+import shutil
+import tarfile
+from time import time
+
+from capreolus.utils.common import download_file
+from capreolus.utils.loginit import get_logger
+from capreolus.utils.trec import document_to_trectxt
+from . import Collection
+
+logger = get_logger(__name__)
+
+
+class MSMarcoMixin:
+    @staticmethod
+    def download_and_extract(url, tmp_dir, expected_fns=None):
+        tmp_dir.mkdir(exist_ok=True, parents=True)
+        gz_name = url.split("/")[-1]
+        output_gz = tmp_dir / gz_name
+        if not output_gz.exists():
+            logger.info(f"Downloading from {url}...")
+            download_file(url, output_gz)
+
+        extract_dir = None
+        t = time()
+        if str(output_gz).endswith("tar.gz"):
+            tmp_dir = tmp_dir / gz_name.replace(".tar.gz", "")
+            logger.info(f"tmp_dir: {tmp_dir}")
+            if not tmp_dir.exists():
+                logger.info(f"{tmp_dir} file does not exist, extracting from {output_gz}...")
+                with tarfile.open(output_gz, "r:gz") as f:
+                    f.extractall(path=tmp_dir)
+
+            if os.path.isdir(tmp_dir):  # and set(os.listdir(tmp_dir)) != expected_fns:
+                extract_dir = tmp_dir
+            elif (not os.path.isdir(tmp_dir)): # and tmp_dir != list(expected_fns)[0]:
+                extract_dir = tmp_dir.parent
+
+        else:
+            outp_fn = tmp_dir / gz_name.replace(".gz", "")
+            if not outp_fn.exists():
+                logger.info(f"{tmp_dir} file does not exist, extracting from {output_gz}...")
+                with gzip.open(output_gz, "rb") as fin, open(outp_fn, "wb") as fout:
+                    shutil.copyfileobj(fin, fout)
+            extract_dir = tmp_dir
+
+        duration = int(time() - t)
+        min, sec = duration // 60, duration % 60
+        logger.info(f"{output_gz} extracted after {duration} seconds (00:{min}:{sec})")
+        return extract_dir
+
+
+@Collection.register
+class MSMarcoPsg(Collection, MSMarcoMixin):
+    module_name = "msmarcopsg"
+    collection_type = "TrecCollection"
+    generator_type = "DefaultLuceneDocumentGenerator"
+    # is_large_collection = True
+
+    def download_raw(self):
+        url = "https://msmarco.blob.core.windows.net/msmarcoranking/collectionandqueries.tar.gz"
+        tmp_dir = self.get_cache_path() / "tmp"
+        expected_fns = {"collection.tsv", "qrels.dev.small.tsv", "qrels.train.tsv", "queries.train.tsv", "queries.dev.small.tsv", "queries.dev.tsv", "queries.eval.small.tsv", "queries.eval.tsv"}
+        gz_dir = self.download_and_extract(url, tmp_dir, expected_fns=expected_fns)
+        return gz_dir
+
+    def download_if_missing(self):
+        coll_dir = self.get_cache_path() / "documents"
+        coll_fn = coll_dir / "msmarco.psg.collection.txt"
+        if coll_fn.exists():
+            return coll_dir
+
+        # convert to trec file
+        coll_tsv_fn = self.download_raw() / "collection.tsv"
+        coll_fn.parent.mkdir(exist_ok=True, parents=True)
+        with open(coll_tsv_fn, "r") as fin, open(coll_fn, "w", encoding="utf-8") as fout:
+            for line in fin:
+                docid, doc = line.strip().split("\t")
+                fout.write(document_to_trectxt(docid, doc))
+
+        return coll_dir

--- a/capreolus/evaluator.py
+++ b/capreolus/evaluator.py
@@ -134,7 +134,8 @@ def search_best_run(runfile_dirs, benchmark, primary_metric, metrics=None, folds
                 runs,
                 benchmark.qrels,
                 [primary_metric],
-                (set(v["train_qids"]) | set(v["predict"]["dev"])),
+                set(v["predict"]["dev"]),
+                # (set(v["train_qids"]) | set(v["predict"]["dev"])),
                 benchmark.relevance_level,
             )[primary_metric]
             if score > best_scores[s][primary_metric]:

--- a/capreolus/searcher/__init__.py
+++ b/capreolus/searcher/__init__.py
@@ -40,9 +40,9 @@ class Searcher(ModuleBase):
         return run
 
     @staticmethod
-    def write_trec_run(preds, outfn):
+    def write_trec_run(preds, outfn, mode="wt"):
         count = 0
-        with open(outfn, "wt") as outf:
+        with open(outfn, mode) as outf:
             qids = sorted(preds.keys(), key=lambda k: int(k))
             for qid in qids:
                 rank = 1

--- a/capreolus/searcher/special.py
+++ b/capreolus/searcher/special.py
@@ -33,8 +33,8 @@ class MsmarcoPsgSearcherMixin:
         return url.split("/")[-1].replace(".gz", "").replace(".tar", "")
 
     def download_and_prepare_train_set(self, tmp_dir):
-        url = "https://msmarco.blob.core.windows.net/msmarcoranking/qidpidtriples.train.full.tsv.gz",
-        extract_file_name = self.get_fn_from_url()
+        url = "https://msmarco.blob.core.windows.net/msmarcoranking/qidpidtriples.train.full.tsv.gz"
+        extract_file_name = self.get_fn_from_url(url)
         extract_dir = self.benchmark.collection.download_and_extract(url, tmp_dir, expected_fns=extract_file_name)
         runs = self.convert_to_trec_runs(extract_dir / extract_file_name, train=True)
         return runs

--- a/capreolus/searcher/special.py
+++ b/capreolus/searcher/special.py
@@ -1,0 +1,113 @@
+import os
+from time import time
+from collections import defaultdict
+from pathlib import Path
+
+from capreolus import ConfigOption, Dependency, constants
+from capreolus.utils.loginit import get_logger
+from capreolus.utils.trec import load_trec_topics, topic_to_trectxt
+
+from . import Searcher
+from .anserini import BM25
+
+logger = get_logger(__name__)
+
+
+class MsmarcoPsgSearcherMixin:
+    @staticmethod
+    def convert_to_trec_runs(msmarco_top1k_fn, train):
+        runs = defaultdict(dict)
+        with open(msmarco_top1k_fn, "r", encoding="utf-8") as f:
+            for line in f:
+               if train:
+                    qid, pos_pid, neg_pid = line.strip().split("\t")
+                    runs[qid][pos_pid] = len(runs.get(pos_pid, []))
+                    runs[qid][neg_pid] = len(runs.get(neg_pid, []))
+               else:
+                    qid, pid, _, _ = line.strip().split("\t")
+                    runs[qid][pid] = len(runs.get(qid, []))
+        return runs
+
+    @staticmethod
+    def get_fn_from_url(url):
+        return url.split("/")[-1].replace(".gz", "").replace(".tar", "")
+
+    def download_and_prepare_train_set(self, tmp_dir):
+        url = "https://msmarco.blob.core.windows.net/msmarcoranking/qidpidtriples.train.full.tsv.gz",
+        extract_file_name = self.get_fn_from_url()
+        extract_dir = self.benchmark.collection.download_and_extract(url, tmp_dir, expected_fns=extract_file_name)
+        runs = self.convert_to_trec_runs(extract_dir / extract_file_name, train=True)
+        return runs
+
+
+@Searcher.register
+class MsmarcoPsg(Searcher, MsmarcoPsgSearcherMixin):
+    module_name = "msmarcopsg"
+    dependencies = [
+        Dependency(key="benchmark", module="benchmark", name="msmarcopsg")
+    ]
+
+    def _query_from_file(self, topicsfn, output_path, cfg):
+        """ only query results in dev and test set are saved """
+        final_runfn = output_path / "searcher"
+        final_donefn = output_path / "done"
+        if os.path.exists(final_donefn):
+            return output_path
+
+        tmp_dir = self.get_cache_path() / "tmp"
+        tmp_dir.mkdir(exist_ok=True, parents=True)
+        output_path.mkdir(exist_ok=True, parents=True)
+
+        # train
+        train_run = self.download_and_prepare_train_set(tmp_dir=tmp_dir)
+        self.write_trec_run(preds=train_run, outfn=final_runfn, mode="wt")
+
+        # dev and test
+        dev_test_urls = [
+            "https://msmarco.blob.core.windows.net/msmarcoranking/top1000.dev.tar.gz",
+            "https://msmarco.blob.core.windows.net/msmarcoranking/top1000.eval.tar.gz"
+        ]
+        runs = {}
+        for url in dev_test_urls:
+            extract_file_name = self.get_fn_from_url(url)
+            extract_dir = self.benchmark.collection.download_and_extract(url, tmp_dir, expected_fns=extract_file_name)
+            runs.update(self.convert_to_trec_runs(extract_dir / extract_file_name, train=False))
+        self.write_trec_run(preds=runs, outfn=final_runfn, mode="a")
+
+        with open(final_donefn, "wt") as f:
+            print("done", file=f)
+        return output_path
+
+
+@Searcher.register
+class MsmarcoPsgBm25(BM25, MsmarcoPsgSearcherMixin):
+    module_name = "msmarcopsgbm25"
+
+    def _query_from_file(self, topicsfn, output_path, config):
+        final_runfn = output_path / "searcher"
+        final_donefn = output_path / "done"
+        if final_donefn.exists():
+            return output_path
+
+        tmp_dir = self.get_cache_path() / "tmp"
+        tmp_topicfn = tmp_dir / os.path.basename(topicsfn)
+        tmp_output_dir = tmp_dir / "BM25_results"
+        tmp_output_dir.mkdir(exist_ok=True, parents=True)
+
+        train_runs = self.download_and_prepare_train_set(tmp_dir=tmp_dir)
+        with open(tmp_topicfn, "wt") as f:
+            for qid, title in load_trec_topics(tmp_topicfn)["title"]:
+                f.write(topic_to_trectxt(qid, title))
+        super()._query_from_file(topicsfn=tmp_topicfn, output_path=tmp_output_dir, config=config)
+        dev_test_runfile = tmp_output_dir / "searcher"
+        assert os.path.exists(dev_test_runfile)
+
+        # write train and dev, test runs into final searcher file
+        Searcher.write_trec_run(train_runs, final_runfn)
+        with open(dev_test_runfile) as fin, open(final_runfn, "a") as fout:
+            for line in fin:
+                fout.write(line)
+
+        with open(final_donefn) as f:
+            f.write("done")
+        return output_path

--- a/capreolus/task/rerank.py
+++ b/capreolus/task/rerank.py
@@ -8,6 +8,7 @@ from capreolus.searcher import Searcher
 from capreolus.task import Task
 from capreolus.utils.loginit import get_logger
 
+from time import time
 logger = get_logger(__name__)
 
 
@@ -38,10 +39,17 @@ class RerankTask(Task):
     def train(self):
         fold = self.config["fold"]
 
+        t1 = time()
         self.rank.search()
+        logger.info(f"Time to rank.search: {time() - t1}")
+        t1 = time()
+
         rank_results = self.rank.evaluate()
+        logger.info(f"Time to rank.evaluate: {time() - t1}")
+        t1 = time()
         best_search_run_path = rank_results["path"][fold]
         best_search_run = Searcher.load_trec_run(best_search_run_path)
+        logger.info(f"Time to load best search run: {time() - t1}")
 
         return self.rerank_run(best_search_run, self.get_results_path())
 

--- a/capreolus/trainer/tensorflow.py
+++ b/capreolus/trainer/tensorflow.py
@@ -209,6 +209,7 @@ class TensorflowTrainer(Trainer):
                         best_metric = metrics[metric]
                         logger.info("new best dev metric: %0.4f", best_metric)
                         wrapped_model.save_weights("{0}/dev.best".format(train_output_path))
+                        logger.info(f"Checkpoint wroted to {train_output_path}")
 
             if num_batches >= self.config["niters"] * self.config["itersize"]:
                 break


### PR DESCRIPTION
Now running ms marco psg while only reranking the top100 data looks right. 

**Confusing stuff to solve**
1. So far none of the runs on reranking top1k could save the checkpoint even tho it seems finished in some cases (but it can be saved in reranking the top100 case). While i was suspecting this is due to the running time limit in slurm, yet everytime queueing up a 4 days runs some other weird bug can pop up so after so many days it is still unconfirmed... 
2. The most recent run throws this error, while the `sampler.generate_example` and `sampler.get_preds_in_trec_format` seem to align with each other, and the dev records are prepared in this run so it's not because of overdue cache data. Still checking what's happening here. (Again this does not happen for the reranking top100 case.) 
```
Traceback (most recent call last):
  File "run.py", line 108, in <module>
    task_entry_function()
  File "/home/czhang/aaai2021/tmp/capreolus/capreolus/task/rerank.py", line 54, in train
    return self.rerank_run(best_search_run, self.get_results_path())
  File "/home/czhang/aaai2021/tmp/capreolus/capreolus/task/rerank.py", line 101, in rerank_run
    self.benchmark.relevance_level,
  File "/home/czhang/aaai2021/tmp/capreolus/capreolus/trainer/tensorflow.py", line 205, in train
    trec_preds = self.get_preds_in_trec_format(dev_predictions, dev_data)
  File "/home/czhang/aaai2021/tmp/capreolus/capreolus/trainer/tensorflow.py", line 429, in get_preds_in_trec_format
    pred_dict[qid][docid] = predictions[i].numpy().astype(np.float16).item()
IndexError: list index out of range
```

**Features/Support to add**
1. right now I have to hack the code to let the ranker only do evaluation on dev qids, otherwise the evaluation there (on millions of training queries!) gonna block the process forever. Probably this is already solved in feature/fit branch where only test qids are evaluated?
2. use sqlite to prepare and store the docid2passage, so this can be run on the RAM-poor machines
3. (maybe less urgent) handle the msmarco downloading using the [allenai/ir_datasets](https://github.com/allenai/ir_datasets)


**Sidenote** (about the running time of some operation)
1.  evaluation (on only dev set, not including the training queries)
1.1 pytrec_eval: 40 sec 
1.2 (trec_eval: 4 secs)
2. Loading the whole runfile (including training data): ~310s (`Saercher.load_trec_run()`)
3. Preparing the passage: ?
4. **Prepare training runs: 3.5 hours**
5. tfrecords (train + dev): 2 hours
6. training: 
6.1 (3k iteration) < 2 hours
6.2 (30k iter) 11~12 hours
7. inference 
7.1 (top100): several hours
7.2 **(top1k) > 1.5 days**

----
Just sending this PR to better track the progress :) Don't worry about it now