### PR TITLE
Add to Replication Log for MS_MARCO.md

### DIFF
--- a/docs/reproduction/MS_MARCO.md
+++ b/docs/reproduction/MS_MARCO.md
@@ -39,3 +39,4 @@ This requires GPU(s) with 48GB memory (e.g. 3 V100 or a RTX 8000) or a TPU.
 ## Replication Logs
 + Results (with hypperparameter-0) replicated by [@crystina-z](https://github.com/crystina-z) on 2020-12-06 (commit [`6c3759f`](https://github.com/crystina-z/capreolus-1/commit/6c3759fe620f18f8939670176a18c744752bc9240)) (Tesla V100 on Compute Canada)
 + Results (with hypperparameter-6) replicated by [@Dahlia-Chehata](https://github.com/Dahlia-Chehata) on 2021-03-29 (commit [`7915aad`](https://github.com/capreolus-ir/capreolus/commit/7915aad75406527a3b88498926cff85259808696)) (Tesla V100 on Compute Canada)
++ Results (MRR@10=0.356) replicated by [@andrewyguo](https://github.com/andrewyguo) on 2021-05-29 (commit [`1ce71d9`](https://github.com/capreolus-ir/capreolus/commit/1ce71d93ab5473b40d4ae02768fd053261b27320)) (Tesla V100 on Compute Canada)


### PR DESCRIPTION
Adding to the replication log for MS_MARCO.md. After setting up Capreolus, running the replication was fairly smooth. 

Training time was initially very long, but, after running `pip install tensorflow-gpu==2.3 --no-deps` in the conda environment, I was able to finish replication in under 20 hours. 
