### PR TITLE
Fix DynamicIRDBenchmark

### DIFF
--- a/capreolus/utils/irds.py
+++ b/capreolus/utils/irds.py
@@ -47,6 +47,7 @@ def get_irds(dataset, query_type, fields):
     @Benchmark.register
     class DynamicIRDBenchmark(IRDBenchmark):
         module_name = ",".join(dataset)
+        ird_dataset_names = dataset
         config_spec = [ConfigOption("query_type", "title")]
 
         @property


### PR DESCRIPTION
I'm not sure if this is the correct way to do it, but it worked for me. Without this change, `ird_dataset_names` is not set and no topics/qrels are ever returned.