### PR TITLE
[3nd sub-PR of #117] allow sampler to keep the queries with no qrels

### DIFF
--- a/capreolus/sampler/__init__.py
+++ b/capreolus/sampler/__init__.py
@@ -24,20 +24,18 @@ class Sampler(ModuleBase):
         """
         self.extractor = extractor
 
-        # remove qids from qid_to_docids that do not have relevance labels in the qrels
-        self.qid_to_docids = {qid: docids for qid, docids in qid_to_docids.items() if qid in qrels}
-        if len(self.qid_to_docids) != len(qid_to_docids):
-            logger.warning(
-                "skipping qids that were missing from the qrels: {}".format(qid_to_docids.keys() - self.qid_to_docids.keys())
-            )
+        self.qid_to_docids = qid_to_docids
+        n_unfound_queries = len([qid for qid in qid_to_docids if qid not in qrels])
+        if n_unfound_queries > 0:
+            logger.warning(f"There are {n_unfound_queries} missing from the qrels in total.")
 
         self.qid_to_reldocs = {
-            qid: [docid for docid in docids if qrels[qid].get(docid, 0) >= relevance_level]
+            qid: [docid for docid in docids if qrels.get(qid, {}).get(docid, 0) >= relevance_level]
             for qid, docids in self.qid_to_docids.items()
         }
         # TODO option to include only negdocs in a top k
         self.qid_to_negdocs = {
-            qid: [docid for docid in docids if qrels[qid].get(docid, 0) < relevance_level]
+            qid: [docid for docid in docids if qrels.get(qid, {}).get(docid, 0) < relevance_level]
             for qid, docids in self.qid_to_docids.items()
         }
 


### PR DESCRIPTION
sub-PR of #117

~1. environmental changes~ #175
~2. handle other trec format~ #176 
**3. allow sampler to keep the queries with no qrels (for msmarco test set) <--**
4. benchmark validation + better error desc
5. CC set up
6. msmarco passage v1 (core files)