### PR TITLE
bugfix - skip validation if qrel/fold file is None

### DIFF
--- a/capreolus/benchmark/__init__.py
+++ b/capreolus/benchmark/__init__.py
@@ -16,7 +16,7 @@ logger = get_logger(__name__)
 
 def validate(build_f):
     def validate_folds_file(self):
-        if not hasattr(self, "fold_file"):
+        if not hasattr(self, "fold_file") or self.fold_file is None:
             logger.warning(f"Folds file is not found for Module {self.module_name}")
             return
 
@@ -35,7 +35,7 @@ def validate(build_f):
         logger.info("Folds file validation finishes.")
 
     def validate_qrels_file(self):
-        if not hasattr(self, "qrel_file"):
+        if not hasattr(self, "qrel_file") or self.qrel_file is None:
             logger.warning(f"Qrel file is not found for Module {self.module_name}")
             return
 

--- a/capreolus/reranker/ConvKNRM.py
+++ b/capreolus/reranker/ConvKNRM.py
@@ -31,7 +31,7 @@ class ConvKNRM_class(nn.Module):
                 self.convs[-1].append(nn.Conv1d(self.embeddings.weight.shape[1], config["filters"], conv_size))
 
         channels = config["maxngram"] ** 2 if config["crossmatch"] else config["maxngram"]
-        channels *= 1 ** 2 if config["crossmatch"] else 1
+        channels *= 1**2 if config["crossmatch"] else 1
         if config["singlefc"]:
             combine_steps = [nn.Linear(self.kernels.count() * channels, 1)]
         else:

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,7 @@ dependencies:
     - oauth2client
     - tensorflow>=2.3,<2.5
     - transformers==4.6.1
-    - tensorflow-ranking
+    - tensorflow-ranking==0.3.2
     - Pillow
     - beautifulsoup4
     - lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ google-api-python-client
 oauth2client
 tensorflow>=2.3,<2.5
 transformers==4.6.0
-tensorflow-ranking
+tensorflow-ranking==0.3.2
 Pillow
 # required for TREC COVID
 beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setuptools.setup(
         "oauth2client",
         "tensorflow>=2.3,<2.5",
         "transformers==4.6.0",
-        "tensorflow-ranking",
+        "tensorflow-ranking==0.3.2",
         "Pillow",
         "beautifulsoup4",
         "lxml",


### PR DESCRIPTION
a quick bug fix, occurring when using some of the IRDBenchmark